### PR TITLE
Add home screen navigation

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'scan_result_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  bool _scanning = false;
+
+  Future<void> _startScan() async {
+    setState(() {
+      _scanning = true;
+    });
+    await Future.delayed(const Duration(seconds: 2));
+    if (!mounted) return;
+    setState(() {
+      _scanning = false;
+    });
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const ScanResultPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ホーム'),
+      ),
+      body: Center(
+        child: _scanning
+            ? const CircularProgressIndicator()
+            : ElevatedButton(
+                onPressed: _startScan,
+                child: const Text('診断開始'),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'scan_result_page.dart';
+import 'home_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -15,87 +15,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const ScanResultPage(),
+      home: const HomePage(),
     );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 3,
-      child: Scaffold(
-        appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-          title: Text(widget.title),
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Home'),
-              Tab(text: '診断'),
-              Tab(text: 'ダミー'),
-            ],
-          ),
-        ),
-        body: TabBarView(
-          children: [
-            Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const Text('You have pushed the button this many times:'),
-                  Text(
-                    '$_counter',
-                    style: Theme.of(context).textTheme.headlineMedium,
-                  ),
-                ],
-              ),
-            ),
-            const DiagnosticPage(),
-            const DummyPage(),
-          ],
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: _incrementCounter,
-          tooltip: 'Increment',
-          child: const Icon(Icons.add),
-        ),
-      ),
-    );
-  }
-}
-
-class DiagnosticPage extends StatelessWidget {
-  const DiagnosticPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: Text('Diagnostic Page'));
-  }
-}
-
-class DummyPage extends StatelessWidget {
-  const DummyPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: Text('Dummy Page'));
   }
 }


### PR DESCRIPTION
## Summary
- show a home page when the app launches
- simulate a scan and open results screen after completion

## Testing
- `flutter --version` *(fails: command not found)*
- `curl https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6877c2c662a48323b907106e112d8788