### PR TITLE
Add Flutter and Python lint workflow

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,27 @@
+name: Analyze
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  flutter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter analyze
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install flake8
+      - run: flake8 scripts

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Continuous Integration
+
+This repository includes a GitHub Actions workflow located at
+`.github/workflows/analyze.yml`. The workflow installs the Flutter SDK and
+runs `flutter analyze` on each push or pull request. It also runs
+`flake8` on the Python files under `scripts/`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running `flutter analyze` and `flake8`
- document CI workflow in README

## Testing
- `flake8 scripts`
- `/tmp/flutter/bin/flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_68783ba37dfc8323a48ea03c9b04a3fa