### PR TITLE
Update widget test for scan flow

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,34 +1,26 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:nwcd_c/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('HomePage scan navigates to ScanResultPage with expected items', (WidgetTester tester) async {
+    // Build the app
     await tester.pumpWidget(const MyApp());
 
-    // Check for the additional tabs
-    expect(find.text('診断'), findsOneWidget);
-    expect(find.text('ダミー'), findsOneWidget);
+    // Verify scan button is present
+    expect(find.text('診断開始'), findsOneWidget);
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Tap the scan button
+    await tester.tap(find.text('診断開始'));
+    await tester.pump(); // start scanning
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    // Wait for the simulated scan duration
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify navigation to the result page
+    expect(find.text('診断結果ページ'), findsOneWidget);
+    expect(find.text('危険ポートの個数（danger_ports）'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- revise `widget_test.dart` to remove counter logic
- add test verifying `HomePage` scan navigation shows `ScanResultPage`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68783b9eeee88323954196369e632656