### PR TITLE
Add dummy page with bottom tabs

### DIFF
--- a/lib/dummy_page.dart
+++ b/lib/dummy_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class DummyPage extends StatelessWidget {
+  const DummyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(
+        title: Text('ダミータブ'),
+      ),
+      body: Center(
+        child: Text('Dummy Page'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'home_page.dart';
+import 'dummy_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -15,7 +16,39 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const HomePage(),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _currentIndex = 0;
+
+  final _pages = const [HomePage(), DummyPage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: IndexedStack(index: _currentIndex, children: _pages),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホームタブ'),
+          BottomNavigationBarItem(icon: Icon(Icons.info), label: 'ダミータブ'),
+        ],
+        onTap: (index) {
+          setState(() {
+            _currentIndex = index;
+          });
+        },
+      ),
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,24 +11,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home and dummy tabs are present', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Check for the additional tabs
-    expect(find.text('診断'), findsOneWidget);
-    expect(find.text('ダミー'), findsOneWidget);
+    expect(find.text('ホームタブ'), findsOneWidget);
+    expect(find.text('ダミータブ'), findsOneWidget);
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Home tab is selected by default, so the scan button should be visible.
+    expect(find.text('診断開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add bottom navigation showing Home and Dummy tabs
- keep existing scan button intact on home tab
- restore original Home page title
- update widget test for the two tabs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878388282bc8323829fe9ae86e62419