### PR TITLE
Add port scan tests and stub results

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'port_scanner.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  final PortScanner scanner;
+
+  const HomePage({super.key, required this.scanner});
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -9,12 +12,19 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   bool _scanning = false;
+  Map<int, bool>? _results;
 
   Future<void> _startScan() async {
-    setState(() => _scanning = true);
-    await Future.delayed(const Duration(seconds: 1));
+    setState(() {
+      _scanning = true;
+      _results = null;
+    });
+    final res = await widget.scanner.scanPorts('localhost', [80]);
     if (!mounted) return;
-    setState(() => _scanning = false);
+    setState(() {
+      _scanning = false;
+      _results = res;
+    });
   }
 
   @override
@@ -24,9 +34,19 @@ class _HomePageState extends State<HomePage> {
       body: Center(
         child: _scanning
             ? const CircularProgressIndicator()
-            : ElevatedButton(
-                onPressed: _startScan,
-                child: const Text('診断開始'),
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: _startScan,
+                    child: const Text('診断開始'),
+                  ),
+                  if (_results != null)
+                    ..._results!.entries
+                        .map((e) => Text('Port ${e.key}: '
+                            '${e.value ? 'open' : 'closed'}'))
+                        .toList(),
+                ],
               ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'home_page.dart';
+import 'port_scanner.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp(scanner: const PortScanner()));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final PortScanner scanner;
+
+  const MyApp({super.key, required this.scanner});
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const HomePage(),
+      home: HomePage(scanner: scanner),
     );
   }
 }

--- a/lib/port_scanner.dart
+++ b/lib/port_scanner.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'dart:io';
+
+class PortScanner {
+  const PortScanner();
+
+  Future<bool> isPortOpen(String host, int port,
+      {Duration timeout = const Duration(seconds: 1)}) async {
+    try {
+      final socket = await Socket.connect(host, port, timeout: timeout);
+      socket.destroy();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<Map<int, bool>> scanPorts(String host, List<int> ports,
+      {Duration timeout = const Duration(seconds: 1)}) async {
+    final results = <int, bool>{};
+    for (final port in ports) {
+      results[port] = await isPortOpen(host, port, timeout: timeout);
+    }
+    return results;
+  }
+}

--- a/test/port_scanner_test.dart
+++ b/test/port_scanner_test.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/port_scanner.dart';
+
+void main() {
+  group('PortScanner', () {
+    const scanner = PortScanner();
+
+    test('isPortOpen returns true for open port and false when closed', () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final port = server.port;
+      expect(await scanner.isPortOpen('localhost', port), isTrue);
+      await server.close();
+      // After closing, the port should no longer be open
+      expect(await scanner.isPortOpen('localhost', port), isFalse);
+    });
+
+    test('scanPorts scans multiple ports', () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final openPort = server.port;
+      final closedPort = openPort + 1;
+      final results = await scanner.scanPorts('localhost', [openPort, closedPort]);
+      expect(results[openPort], isTrue);
+      expect(results[closedPort], isFalse);
+      await server.close();
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:nwcd_c/main.dart';
+import 'package:nwcd_c/port_scanner.dart';
 
 void main() {
   testWidgets('HomePage shows scan button', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp(scanner: const PortScanner()));
 
     expect(find.text('診断開始'), findsOneWidget);
 
@@ -13,5 +14,27 @@ void main() {
     await tester.pump();
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('Scan results appear after tapping button',
+      (WidgetTester tester) async {
+    class FakePortScanner extends PortScanner {
+      const FakePortScanner();
+
+      @override
+      Future<Map<int, bool>> scanPorts(String host, List<int> ports,
+              {Duration timeout = const Duration(seconds: 1)}) async =>
+          {for (final p in ports) p: true};
+
+      @override
+      Future<bool> isPortOpen(String host, int port,
+              {Duration timeout = const Duration(seconds: 1)}) async =>
+          true;
+    }
+
+    await tester.pumpWidget(MyApp(scanner: const FakePortScanner()));
+    await tester.tap(find.text('診断開始'));
+    await tester.pump();
+    expect(find.text('Port 80: open'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add a simple `PortScanner` utility class
- update `HomePage` and `MyApp` to use the scanner and display results
- create unit tests for the scanner
- extend widget test to verify scan results show up

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a4221db88323a8c6a53d58475993