### PR TITLE
Add port scan results page

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'results_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -15,6 +16,23 @@ class _HomePageState extends State<HomePage> {
     await Future.delayed(const Duration(seconds: 1));
     if (!mounted) return;
     setState(() => _scanning = false);
+
+    final results = [
+      const PortInfo(21, true),
+      const PortInfo(22, false),
+      const PortInfo(23, true),
+      const PortInfo(80, true),
+      const PortInfo(443, true),
+      const PortInfo(445, false),
+    ];
+
+    if (mounted) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => ResultsPage(results: results),
+        ),
+      );
+    }
   }
 
   @override

--- a/lib/results_page.dart
+++ b/lib/results_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+class PortInfo {
+  const PortInfo(this.port, this.open);
+
+  final int port;
+  final bool open;
+}
+
+class ResultsPage extends StatelessWidget {
+  const ResultsPage({super.key, required this.results});
+
+  final List<PortInfo> results;
+
+  static const dangerousPorts = {21, 23, 25, 445};
+
+  int get dangerousOpenCount =>
+      results.where((p) => p.open && dangerousPorts.contains(p.port)).length;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Scan Results')),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final content = Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Card(
+                  color: Colors.red.shade100,
+                  child: ListTile(
+                    title: const Text('Dangerous Ports'),
+                    subtitle: Text('$dangerousOpenCount open'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: results.length,
+                    itemBuilder: (context, index) {
+                      final port = results[index];
+                      return Card(
+                        child: ListTile(
+                          title: Text('Port ${port.port}'),
+                          trailing: Text(
+                            port.open ? 'Open' : 'Closed',
+                            style: TextStyle(
+                              color:
+                                  port.open ? Colors.red : Colors.green,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+          if (constraints.maxWidth > 600) {
+            return Center(
+              child: SizedBox(width: 600, child: content),
+            );
+          }
+          return content;
+        },
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,14 +4,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 
 void main() {
-  testWidgets('HomePage shows scan button', (WidgetTester tester) async {
+  testWidgets('Scan navigates to results page', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    expect(find.text('診断開始'), findsOneWidget);
 
     await tester.tap(find.text('診断開始'));
     await tester.pump();
+    // Wait for fake scan delay
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Scan Results'), findsOneWidget);
+    expect(find.text('Port 21'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- show a results screen after scanning
- list each port's status and display a card with the count of dangerous open ports
- update widget test for new results page

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879a41cc9308323ba362d0e938a1936