### PR TITLE
Inject PortScanner via constructor

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -21,7 +21,8 @@ class _HomePageState extends State<HomePage> {
     });
 
     final ports = [21, 22, 80, 443, 445, 3389];
-    final results = await scanPorts('127.0.0.1', ports);
+    final scanMap = await widget.scanner.scanPorts('127.0.0.1', ports);
+    final results = mapToScanResults(scanMap);
 
     if (!mounted) return;
     setState(() {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,8 +5,22 @@ import 'package:nwcd_c/main.dart';
 import 'package:nwcd_c/port_scanner.dart';
 
 void main() {
+  class FakePortScanner extends PortScanner {
+    const FakePortScanner();
+
+    @override
+    Future<Map<int, bool>> scanPorts(String host, List<int> ports,
+            {Duration timeout = const Duration(seconds: 1)}) async =>
+        {for (final p in ports) p: true};
+
+    @override
+    Future<bool> isPortOpen(String host, int port,
+            {Duration timeout = const Duration(seconds: 1)}) async =>
+        true;
+  }
+
   testWidgets('HomePage scans and displays results', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp(scanner: const FakePortScanner()));
     await tester.tap(find.text('診断開始'));
     await tester.pump();
     // Wait for fake scan delay
@@ -19,20 +33,6 @@ void main() {
 
   testWidgets('Scan results appear after tapping button',
       (WidgetTester tester) async {
-    class FakePortScanner extends PortScanner {
-      const FakePortScanner();
-
-      @override
-      Future<Map<int, bool>> scanPorts(String host, List<int> ports,
-              {Duration timeout = const Duration(seconds: 1)}) async =>
-          {for (final p in ports) p: true};
-
-      @override
-      Future<bool> isPortOpen(String host, int port,
-              {Duration timeout = const Duration(seconds: 1)}) async =>
-          true;
-    }
-
     await tester.pumpWidget(MyApp(scanner: const FakePortScanner()));
     await tester.tap(find.text('診断開始'));
     await tester.pump();


### PR DESCRIPTION
## Summary
- introduce `PortScanner` class with `isPortOpen` and `scanPorts`
- convert scan results to `PortScanResult` with `mapToScanResults`
- use injected `PortScanner` instance in `HomePage`
- update widget tests to pass a `FakePortScanner`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879dfdfc7e88323935d4087a02f94d6