### PR TITLE
Implement PortScanner class and update HomePage

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -21,7 +21,15 @@ class _HomePageState extends State<HomePage> {
     });
 
     final ports = [21, 22, 80, 443, 445, 3389];
-    final results = await scanPorts('127.0.0.1', ports);
+    final portMap = await widget.scanner.scanPorts('127.0.0.1', ports);
+    final results = <PortScanResult>[];
+    for (final entry in portMap.entries) {
+      if (entry.value) {
+        results.add(
+          PortScanResult(entry.key, dangerous: dangerousPorts.contains(entry.key)),
+        );
+      }
+    }
 
     if (!mounted) return;
     setState(() {


### PR DESCRIPTION
## Summary
- add `PortScanner` class with `scanPorts` and `isPortOpen`
- refactor `HomePage` to use `PortScanner` for scanning
- tests now import the new class already (no changes needed)

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a01cbd80c8323854e96ef7aca8aa6