### PR TITLE
Add real-time and full scan buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nwcd_c
 
-This Flutter project contains only a minimal home screen. Tapping **診断開始** shows a short progress indicator.
+This Flutter project contains only a minimal home screen. Tapping **リアルタイム** or **フルスキャン** shows a short progress indicator.
 
 For general Flutter setup instructions, see the [online documentation](https://docs.flutter.dev/).

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -8,64 +8,46 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  bool _loading = false;
+  bool _realtimeLoading = false;
+  bool _fullScanLoading = false;
 
-  Future<void> _startScan() async {
-    setState(() => _loading = true);
+  Future<void> _startRealTimeScan() async {
+    setState(() => _realtimeLoading = true);
     await Future.delayed(const Duration(seconds: 1));
     if (!mounted) return;
-    setState(() => _loading = false);
+    setState(() => _realtimeLoading = false);
+  }
+
+  Future<void> _startFullScan() async {
+    setState(() => _fullScanLoading = true);
+    await Future.delayed(const Duration(seconds: 1));
+    if (!mounted) return;
+    setState(() => _fullScanLoading = false);
   }
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = _realtimeLoading || _fullScanLoading;
     return Scaffold(
       appBar: AppBar(title: const Text('ホーム')),
       body: Center(
-        child: _loading
+        child: isLoading
             ? const CircularProgressIndicator()
-            : ElevatedButton(
-                      onPressed: _startScan,
-                      child: const Text('診断開始'),
-                    ),
-                  )
-                : _buildResults(),
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: _startRealTimeScan,
+                    child: const Text('リアルタイム'),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _startFullScan,
+                    child: const Text('フルスキャン'),
+                  ),
+                ],
+              ),
       ),
-    );
-  }
-  Widget _buildResults() {
-    final dangerousCount =
-        _results!.where((r) => r.dangerous).length;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text('危険なポート数: $dangerousCount'),
-        const SizedBox(height: 8),
-        Expanded(
-          child: ListView.builder(
-            itemCount: _results!.length,
-            itemBuilder: (context, index) {
-              final result = _results![index];
-              return ListTile(
-                title: Text('Port ${result.port}'),
-                trailing: result.dangerous
-                    ? const Text(
-                        'Danger',
-                        style: TextStyle(color: Colors.red),
-                      )
-                    : null,
-              );
-            },
-          ),
-        ),
-        const SizedBox(height: 16),
-        Center(
-          child: ElevatedButton(
-            onPressed: _startScan,
-            child: const Text('再診断'),
-          ),
-        ),
-      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace old 診断開始 button with two buttons: リアルタイム and フルスキャン
- update README to mention the new buttons

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a740de46c8323902879d8fb921031