### PR TITLE
Add widget tests and result page

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'result_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -23,6 +24,10 @@ class _HomePageState extends State<HomePage> {
     await Future.delayed(const Duration(seconds: 1));
     if (!mounted) return;
     setState(() => _fullScanLoading = false);
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const ResultPage()),
+    );
   }
 
   @override

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ResultPage extends StatelessWidget {
+  const ResultPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('結果')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('完了'),
+        ),
+      ),
+    );
+  }
+}

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/main.dart';
+
+void main() {
+  testWidgets('Real-time and full scan flows', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    // Tap the real-time scan button
+    await tester.tap(find.text('リアルタイム'));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    // Wait for the scan to finish
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+    expect(find.text('リアルタイム'), findsOneWidget);
+    expect(find.text('フルスキャン'), findsOneWidget);
+
+    // Tap the full scan button
+    await tester.tap(find.text('フルスキャン'));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    // Wait for navigation to result page
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    // Verify result page shows a completion button
+    expect(find.text('完了'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a new `ResultPage`
- launch it after a full scan finishes
- test real-time and full scan flows

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7bce1dd88323bcfceaca6878875a