### PR TITLE
Add device version scan simulation

### DIFF
--- a/lib/device_version_scan.dart
+++ b/lib/device_version_scan.dart
@@ -1,0 +1,45 @@
+class DeviceInfo {
+  final String name;
+  final String osVersion;
+  final String firmwareVersion;
+  final String softwareVersion;
+  final bool vulnerable;
+
+  const DeviceInfo({
+    required this.name,
+    required this.osVersion,
+    required this.firmwareVersion,
+    required this.softwareVersion,
+    required this.vulnerable,
+  });
+}
+
+Future<List<DeviceInfo>> deviceVersionScan() async {
+  // In a real implementation this function would scan the network and
+  // query each device for its firmware and software versions. For this
+  // example we just return a simulated list of devices.
+  await Future.delayed(const Duration(seconds: 1));
+  return const [
+    DeviceInfo(
+      name: 'Router',
+      osVersion: '1.0.0',
+      firmwareVersion: '2.0.0',
+      softwareVersion: '3.0.0',
+      vulnerable: false,
+    ),
+    DeviceInfo(
+      name: 'Camera',
+      osVersion: '5.0.1',
+      firmwareVersion: '1.2.3',
+      softwareVersion: '4.5.6',
+      vulnerable: true,
+    ),
+    DeviceInfo(
+      name: 'NAS',
+      osVersion: '2.5.0',
+      firmwareVersion: '2.5.0',
+      softwareVersion: '2.5.0',
+      vulnerable: false,
+    ),
+  ];
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'device_version_scan.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -20,9 +21,43 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _startFullScan() async {
     setState(() => _fullScanLoading = true);
-    await Future.delayed(const Duration(seconds: 1));
+    final devices = await deviceVersionScan();
     if (!mounted) return;
     setState(() => _fullScanLoading = false);
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('スキャン結果'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (final device in devices)
+                ListTile(
+                  title: Text(device.name),
+                  subtitle: Text(
+                    'OS: ${device.osVersion}\n'
+                    'FW: ${device.firmwareVersion}\n'
+                    'SW: ${device.softwareVersion}',
+                  ),
+                  trailing: Text(
+                    device.vulnerable ? '脆弱性あり' : '安全',
+                    style: TextStyle(
+                      color: device.vulnerable ? Colors.red : Colors.black,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- simulate network device version scan
- show vulnerability status in the UI when full scan is triggered

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7d4592f48323a2cc72be9f9bab74