### PR TITLE
Add concurrent realtime and full scan tabs

### DIFF
--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -6,19 +6,15 @@ void main() {
   testWidgets('Real-time and full scan flows', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Tap the real-time scan button
-    await tester.tap(find.text('リアルタイム'));
+    // Start real-time scanning
+    await tester.tap(find.text('リアルタイム開始'));
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-    // Wait for the scan to finish
-    await tester.pump(const Duration(seconds: 1));
-    await tester.pumpAndSettle();
-    expect(find.text('リアルタイム'), findsOneWidget);
-    expect(find.text('フルスキャン'), findsOneWidget);
-
     // Tap the full scan button
     await tester.tap(find.text('フルスキャン'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('フルスキャン開始'));
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 


### PR DESCRIPTION
## Summary
- allow realtime scanning to run continuously using a timer
- run full scan while realtime scan is active
- update UI with start/stop controls
- adjust widget test for new tab layout

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8308659083238f55974d2fa8d1ab