### PR TITLE
Implement simulated port scanning results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nwcd_c
 
-This Flutter project contains only a minimal home screen. Tapping **リアルタイム** or **フルスキャン** shows a short progress indicator.
+This Flutter project contains only a minimal home screen. Tapping **リアルタイム** shows a short progress indicator.
+
+The **フルスキャン** button displays a simulated report of open ports for devices on the local network. The report lists each monitored port, its associated risk and the devices that expose the port.
 
 For general Flutter setup instructions, see the [online documentation](https://docs.flutter.dev/).

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'device_version_scan.dart';
+import 'port_scan.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -21,32 +21,45 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _startFullScan() async {
     setState(() => _fullScanLoading = true);
-    final devices = await deviceVersionScan();
+    final results = await portScan();
     if (!mounted) return;
     setState(() => _fullScanLoading = false);
     await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('スキャン結果'),
+        title: const Text('ポート開放チェック結果'),
         content: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              for (final device in devices)
-                ListTile(
-                  title: Text(device.name),
-                  subtitle: Text(
-                    'OS: ${device.osVersion}\n'
-                    'FW: ${device.firmwareVersion}\n'
-                    'SW: ${device.softwareVersion}',
-                  ),
-                  trailing: Text(
-                    device.vulnerable ? '脆弱性あり' : '安全',
-                    style: TextStyle(
-                      color: device.vulnerable ? Colors.red : Colors.black,
-                    ),
+              for (final result in results) ...[
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('ポート：${result.port}'),
+                      Text('リスク：${result.risk}'),
+                    ],
                   ),
                 ),
+                DataTable(
+                  columns: const [
+                    DataColumn(label: Text('IPアドレス')),
+                    DataColumn(label: Text('ホスト名')),
+                    DataColumn(label: Text('コメント')),
+                  ],
+                  rows: [
+                    for (final entry in result.entries)
+                      DataRow(cells: [
+                        DataCell(Text(entry.ipAddress)),
+                        DataCell(Text(entry.hostName)),
+                        DataCell(Text(entry.comment)),
+                      ]),
+                  ],
+                ),
+                const SizedBox(height: 16),
+              ],
             ],
           ),
         ),

--- a/lib/port_scan.dart
+++ b/lib/port_scan.dart
@@ -1,0 +1,72 @@
+class PortScanEntry {
+  final String ipAddress;
+  final String hostName;
+  final String comment;
+
+  const PortScanEntry({
+    required this.ipAddress,
+    required this.hostName,
+    required this.comment,
+  });
+}
+
+class PortScanResult {
+  final int port;
+  final String risk;
+  final List<PortScanEntry> entries;
+
+  const PortScanResult({
+    required this.port,
+    required this.risk,
+    required this.entries,
+  });
+}
+
+Future<List<PortScanResult>> portScan() async {
+  await Future.delayed(const Duration(seconds: 1));
+  return const [
+    PortScanResult(
+      port: 3389,
+      risk: 'リモート接続が有効。乗っ取りリスクあり',
+      entries: [
+        PortScanEntry(
+          ipAddress: '192.168.1.10',
+          hostName: 'office-pc-01',
+          comment: 'RDPが開放されています（リモート接続リスク）',
+        ),
+        PortScanEntry(
+          ipAddress: '192.168.1.22',
+          hostName: 'server-01',
+          comment: '社内サーバにリモート接続可能。要対策',
+        ),
+      ],
+    ),
+    PortScanResult(
+      port: 445,
+      risk: 'ファイル共有サービス。ウイルス拡散リスク',
+      entries: [
+        PortScanEntry(
+          ipAddress: '192.168.1.15',
+          hostName: 'pc-sales01',
+          comment: 'ファイル共有有効。ウイルス感染リスク高',
+        ),
+        PortScanEntry(
+          ipAddress: '192.168.1.20',
+          hostName: 'nas-office',
+          comment: 'NASが445番開放。ランサム感染に注意',
+        ),
+      ],
+    ),
+    PortScanResult(
+      port: 23,
+      risk: '古いリモート操作。認証なし。',
+      entries: [
+        PortScanEntry(
+          ipAddress: '192.168.1.30',
+          hostName: 'iot-printer',
+          comment: 'Telnet有効。旧式の設定で危険性あり',
+        ),
+      ],
+    ),
+  ];
+}


### PR DESCRIPTION
## Summary
- add a port scan simulation
- show the port scan results when tapping **フルスキャン**
- update README to mention new behaviour

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b27cf60e883238ce293839f2787c1