### PR TITLE
Implement simulated device scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nwcd_c
 
-This Flutter project contains only a minimal home screen. Tapping **リアルタイム** or **フルスキャン** shows a short progress indicator.
+This Flutter project contains a minimal home screen. Tapping **リアルタイム** shows a short progress indicator. Tapping **フルスキャン** performs a simulated device scan and displays a table of devices that require updates or expose known vulnerabilities.
 
 For general Flutter setup instructions, see the [online documentation](https://docs.flutter.dev/).

--- a/lib/device_version_scan.dart
+++ b/lib/device_version_scan.dart
@@ -1,45 +1,51 @@
 class DeviceInfo {
+  final String ip;
   final String name;
   final String osVersion;
-  final String firmwareVersion;
-  final String softwareVersion;
-  final bool vulnerable;
+  final bool osUpdatePending;
+  final bool rdpPortOpen;
+  final bool cveVulnerable;
 
   const DeviceInfo({
+    required this.ip,
     required this.name,
     required this.osVersion,
-    required this.firmwareVersion,
-    required this.softwareVersion,
-    required this.vulnerable,
+    required this.osUpdatePending,
+    required this.rdpPortOpen,
+    required this.cveVulnerable,
   });
 }
 
 Future<List<DeviceInfo>> deviceVersionScan() async {
-  // In a real implementation this function would scan the network and
-  // query each device for its firmware and software versions. For this
-  // example we just return a simulated list of devices.
+  // NOTE: In a production environment this function would scan the local
+  // network, query devices for version information and check them against
+  // known vulnerability databases. This demo returns fixed values so that the
+  // UI can display an example result without performing real network access.
   await Future.delayed(const Duration(seconds: 1));
   return const [
     DeviceInfo(
-      name: 'Router',
-      osVersion: '1.0.0',
-      firmwareVersion: '2.0.0',
-      softwareVersion: '3.0.0',
-      vulnerable: false,
+      ip: '192.168.0.2',
+      name: 'PC-A',
+      osVersion: 'Windows 10 20H2',
+      osUpdatePending: false,
+      rdpPortOpen: true,
+      cveVulnerable: false,
     ),
     DeviceInfo(
-      name: 'Camera',
-      osVersion: '5.0.1',
-      firmwareVersion: '1.2.3',
-      softwareVersion: '4.5.6',
-      vulnerable: true,
+      ip: '192.168.0.7',
+      name: 'PC-B',
+      osVersion: 'Windows 8',
+      osUpdatePending: true,
+      rdpPortOpen: false,
+      cveVulnerable: false,
     ),
     DeviceInfo(
-      name: 'NAS',
-      osVersion: '2.5.0',
-      firmwareVersion: '2.5.0',
-      softwareVersion: '2.5.0',
-      vulnerable: false,
+      ip: '192.168.0.9',
+      name: 'IoT-Camera',
+      osVersion: '1.3.0',
+      osUpdatePending: false,
+      rdpPortOpen: false,
+      cveVulnerable: true,
     ),
   ];
 }

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -24,29 +24,37 @@ class _HomePageState extends State<HomePage> {
     final devices = await deviceVersionScan();
     if (!mounted) return;
     setState(() => _fullScanLoading = false);
+
+    String formatDevices(Iterable<DeviceInfo> info) =>
+        info.map((d) => '${d.ip} (${d.name})').join(', ');
+
+    final osPending = formatDevices(devices.where((d) => d.osUpdatePending));
+    final rdpOpen = formatDevices(devices.where((d) => d.rdpPortOpen));
+    final cveVuln = formatDevices(devices.where((d) => d.cveVulnerable));
+
     await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('スキャン結果'),
         content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              for (final device in devices)
-                ListTile(
-                  title: Text(device.name),
-                  subtitle: Text(
-                    'OS: ${device.osVersion}\n'
-                    'FW: ${device.firmwareVersion}\n'
-                    'SW: ${device.softwareVersion}',
-                  ),
-                  trailing: Text(
-                    device.vulnerable ? '脆弱性あり' : '安全',
-                    style: TextStyle(
-                      color: device.vulnerable ? Colors.red : Colors.black,
-                    ),
-                  ),
-                ),
+          child: DataTable(
+            columns: const [
+              DataColumn(label: Text('スキャン項目')),
+              DataColumn(label: Text('リスクのある端末一覧')),
+            ],
+            rows: [
+              DataRow(cells: [
+                const DataCell(Text('OSアップデート未適用')),
+                DataCell(Text(osPending.isNotEmpty ? osPending : '-')),
+              ]),
+              DataRow(cells: [
+                const DataCell(Text('RDPポート開放 (3389)')),
+                DataCell(Text(rdpOpen.isNotEmpty ? rdpOpen : '-')),
+              ]),
+              DataRow(cells: [
+                const DataCell(Text('CVE脆弱性検出あり')),
+                DataCell(Text(cveVuln.isNotEmpty ? cveVuln : '-')),
+              ]),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- extend `deviceVersionScan` with stubbed device info
- show scan results in a table on full scan
- update README about scanning behavior

## Testing
- `dart format lib/device_version_scan.dart lib/home_page.dart` *(fails: `bash: command not found: dart`)*

------
https://chatgpt.com/codex/tasks/task_e_687b29a29a70832398bb4ee36de1dc3f