### PR TITLE
Implement real device scanning

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -53,12 +53,17 @@ class _HomePageState extends State<HomePage>
     setState(() => _fullScanLoading = true);
     final device = await scanDeviceVersion();
     final ports = await checkOpenPorts();
+    final cves = await scanLocalCveVulnerabilities();
     if (!mounted) return;
     setState(() => _fullScanLoading = false);
     if (!mounted) return;
     await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (_) => ResultPage(deviceInfo: device, portInfo: ports),
+        builder: (_) => ResultPage(
+          deviceInfo: device,
+          portInfo: ports,
+          vulnerabilityInfo: cves,
+        ),
       ),
     );
   }

--- a/lib/result_page.dart
+++ b/lib/result_page.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 class ResultPage extends StatelessWidget {
   final String deviceInfo;
   final String portInfo;
+  final String vulnerabilityInfo;
 
   const ResultPage({
     super.key,
     required this.deviceInfo,
     required this.portInfo,
+    required this.vulnerabilityInfo,
   });
 
   @override
@@ -26,6 +28,10 @@ class ResultPage extends StatelessWidget {
             Text('ポート開放状況', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             Text(portInfo),
+            const SizedBox(height: 16),
+            Text('脆弱性情報', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(vulnerabilityInfo),
             const Spacer(),
             Center(
               child: ElevatedButton(

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -1,11 +1,58 @@
 import 'dart:async';
+import 'dart:io';
 
+/// Returns basic operating system information for the current device.
+///
+/// The function uses [Platform.operatingSystem] and
+/// [Platform.operatingSystemVersion] to gather real data rather than the
+/// hard coded values previously returned.
 Future<String> scanDeviceVersion() async {
   await Future.delayed(const Duration(seconds: 1));
-  return 'Device version: 1.0';
+  final os = Platform.operatingSystem;
+  final version = Platform.operatingSystemVersion;
+  return 'Device OS: $os\nVersion: $version';
 }
 
+/// Checks a handful of common ports on localhost and lists the ones that are
+/// accepting connections.
+///
+/// Currently ports 3389 (RDP), 80, 443 and 22 are tested. The scan runs with a
+/// short timeout so the function returns quickly when ports are closed.
 Future<String> checkOpenPorts() async {
-  await Future.delayed(const Duration(seconds: 1));
-  return 'Open ports: 80, 443';
+  const ports = [3389, 80, 443, 22];
+  final openPorts = <int>[];
+  for (final port in ports) {
+    try {
+      final socket =
+          await Socket.connect('127.0.0.1', port, timeout: const Duration(milliseconds: 200));
+      await socket.close();
+      openPorts.add(port);
+    } catch (_) {
+      // Connection failed - port is likely closed.
+    }
+  }
+  await Future.delayed(const Duration(milliseconds: 500));
+  return openPorts.isEmpty
+      ? 'No open ports detected'
+      : 'Open ports: ${openPorts.join(', ')}';
+}
+
+/// Performs a very small local CVE lookup based on the OS information.
+///
+/// Without network access a tiny built in database is used. If no matches are
+/// found the function returns a message saying so.
+Future<String> scanLocalCveVulnerabilities() async {
+  await Future.delayed(const Duration(milliseconds: 500));
+  final version = Platform.operatingSystemVersion.toLowerCase();
+  final vulnerabilities = <String>[];
+
+  if (version.contains('ubuntu 20.04')) {
+    vulnerabilities.add('CVE-2021-3156');
+  } else if (version.contains('windows')) {
+    vulnerabilities.add('CVE-2020-0601');
+  }
+
+  return vulnerabilities.isEmpty
+      ? 'No known CVEs found'
+      : 'Potential CVEs: ${vulnerabilities.join(', ')}';
 }

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -16,11 +16,12 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     // Wait for scan to finish and result page to appear
-    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
 
     expect(find.text('デバイス情報'), findsOneWidget);
     expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.text('脆弱性情報'), findsOneWidget);
 
     await tester.tap(find.text('完了'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- use actual `Platform` values for device info
- check common localhost ports for open status
- add a simple CVE lookup function using a small local database
- display vulnerability info in result page
- test updated to expect the new UI labels

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b3d3d75c48323bdea5781fd4fbe89