### PR TITLE
Add network diagram tab to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nwcd_c
 
-This Flutter project contains a minimal home screen with two buttons:
-**リアルタイム** for a quick real-time scan and **フルスキャン** for a full
-network scan. Pressing either button shows a short progress indicator. Once the
+This Flutter project contains a minimal home screen with three tabs:
+**リアルタイム診断** for a quick real-time scan, **フルスキャン** for a full
+network scan, and **ネットワーク図** for displaying a network diagram.
+Pressing either scan button shows a short progress indicator. Once the
 actual scanning logic is implemented, each workflow will navigate to a results
 page summarizing the findings.
 
@@ -17,6 +18,10 @@ page summarizing the findings.
 1. Tap **フルスキャン** on the home screen.
 2. A more thorough scan is executed and a progress indicator is shown.
 3. After completion, the app navigates to the results page.
+
+### Network diagram
+1. Tap **ネットワーク図** on the home screen.
+2. A placeholder diagram is displayed showing where network visuals will appear.
 
 **Note:** Only run network scans against systems you are authorized to test.
 Unauthorized scanning can be illegal or violate terms of service.

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -21,7 +21,7 @@ class _HomePageState extends State<HomePage>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController = TabController(length: 3, vsync: this);
   }
 
   void _startRealTimeScan() {
@@ -73,6 +73,7 @@ class _HomePageState extends State<HomePage>
           tabs: const [
             Tab(text: 'リアルタイム診断'),
             Tab(text: 'フルスキャン'),
+            Tab(text: 'ネットワーク図'),
           ],
         ),
       ),
@@ -81,6 +82,7 @@ class _HomePageState extends State<HomePage>
         children: [
           _buildRealtimeTab(),
           _buildFullScanTab(),
+          _buildNetworkDiagramTab(),
         ],
       ),
     );
@@ -121,6 +123,19 @@ class _HomePageState extends State<HomePage>
                 ),
               ],
             ),
+    );
+  }
+
+  Widget _buildNetworkDiagramTab() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Icon(Icons.network_check, size: 96),
+          SizedBox(height: 16),
+          Text('ネットワーク図がここに表示されます'),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- include a new **ネットワーク図** tab alongside realtime diagnostics and full scan
- show a placeholder network diagram on that tab
- document the new tab in the README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b3ec27780832394808d429d9925cd