### PR TITLE
Update full scan tab behavior

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'scanner.dart';
-import 'result_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -15,6 +14,8 @@ class _HomePageState extends State<HomePage>
   late final TabController _tabController;
   bool _realtimeRunning = false;
   bool _fullScanLoading = false;
+  String? _deviceInfo;
+  String? _portInfo;
   final List<String> _realtimeLogs = [];
   Timer? _realtimeTimer;
 
@@ -50,17 +51,19 @@ class _HomePageState extends State<HomePage>
   }
 
   Future<void> _startFullScan() async {
-    setState(() => _fullScanLoading = true);
+    setState(() {
+      _fullScanLoading = true;
+      _deviceInfo = null;
+      _portInfo = null;
+    });
     final device = await scanDeviceVersion();
     final ports = await checkOpenPorts();
     if (!mounted) return;
-    setState(() => _fullScanLoading = false);
-    if (!mounted) return;
-    await Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ResultPage(deviceInfo: device, portInfo: ports),
-      ),
-    );
+    setState(() {
+      _fullScanLoading = false;
+      _deviceInfo = device;
+      _portInfo = ports;
+    });
   }
 
   @override
@@ -111,18 +114,30 @@ class _HomePageState extends State<HomePage>
 
   Widget _buildFullScanTab() {
     final isLoading = _fullScanLoading;
-    return Center(
-      child: isLoading
-          ? const CircularProgressIndicator()
-          : Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ElevatedButton(
-                  onPressed: _startFullScan,
-                  child: const Text('フルスキャン開始'),
-                ),
-              ],
-            ),
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ElevatedButton(
+            onPressed: isLoading ? null : _startFullScan,
+            child: const Text('フルスキャン開始'),
+          ),
+          const SizedBox(height: 16),
+          if (isLoading) const CircularProgressIndicator(),
+          if (!isLoading && _deviceInfo != null && _portInfo != null) ...[
+            Text('デバイス情報',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(_deviceInfo!),
+            const SizedBox(height: 16),
+            Text('ポート開放状況',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(_portInfo!),
+          ],
+        ],
+      ),
     );
   }
 

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 
 void main() {
-  testWidgets('Full scan shows results', (WidgetTester tester) async {
+  testWidgets('Full scan shows results in tab', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     // Navigate to full scan tab
@@ -15,16 +15,12 @@ void main() {
     await tester.pump();
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-    // Wait for scan to finish and result page to appear
+    // Wait for scan to finish and results to display
     await tester.pump(const Duration(seconds: 2));
     await tester.pumpAndSettle();
 
     expect(find.text('デバイス情報'), findsOneWidget);
     expect(find.text('ポート開放状況'), findsOneWidget);
-
-    await tester.tap(find.text('完了'));
-    await tester.pumpAndSettle();
-
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- display full scan results directly in the tab
- remove navigation to separate result page
- update test to expect results in the tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5a92a6c8832395d8d4b2da017aa0