### PR TITLE
Update README with device_version_scan details

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,35 @@ page summarizing the findings.
 ### Full scan
 1. Tap **フルスキャン** on the home screen.
 2. A more thorough scan is executed and a progress indicator is shown.
-3. After completion, the app navigates to the results page.
+3. The workflow invokes **device_version_scan** to collect OS, firmware,
+   and installed software versions from discovered devices.
+4. After completion, the app navigates to the results page.
 
 ### Network diagram
 1. Tap **ネットワーク図** on the home screen.
 2. A placeholder diagram is displayed showing where network visuals will appear.
 
-**Note:** Only run network scans against systems you are authorized to test.
-Unauthorized scanning can be illegal or violate terms of service.
+**Note:** Only scan devices or networks that you own or are explicitly
+authorized to test. Unauthorized or intrusive scanning can be illegal and may
+violate terms of service or trigger security defenses.
+
+### Device version scan
+The `device_version_scan` workflow gathers operating system, firmware, and
+software versions from devices found in a full scan. It uses tools such as
+`nmap` with service detection or vendor APIs (SNMP, HTTP, etc.) to query each
+host and report version details. The information can reveal outdated or
+vulnerable software running on the network.
+
+#### Dependencies and setup
+1. Install **nmap** so that the scan can perform service and version detection:
+   ```bash
+   sudo apt-get update && sudo apt-get install -y nmap
+   ```
+2. Ensure the `nmap` command is in your `PATH` and accessible to the app.
+3. Configure any vendor-specific APIs or authentication if required.
+
+**Caution:** Performing version scans can trigger security alerts and may be
+illegal without permission. Always obtain authorization before scanning devices.
 
 ## Running the app
 1. Install Flutter and fetch dependencies with `flutter pub get`.


### PR DESCRIPTION
## Summary
- document `device_version_scan` in README
- warn about authorized scanning only
- list `nmap` as an external dependency and show setup
- revise full scan workflow to include version scan

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6108a39c832387d4b257743f29c0