### PR TITLE
Add DeviceInfo table and mockable scan

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -14,7 +14,7 @@ class _HomePageState extends State<HomePage>
   late final TabController _tabController;
   bool _realtimeRunning = false;
   bool _fullScanLoading = false;
-  String? _deviceInfo;
+  List<DeviceInfo>? _deviceInfo;
   String? _portInfo;
   final List<String> _realtimeLogs = [];
   Timer? _realtimeTimer;
@@ -56,7 +56,7 @@ class _HomePageState extends State<HomePage>
       _deviceInfo = null;
       _portInfo = null;
     });
-    final device = await scanDeviceVersion();
+    final device = await deviceVersionScan();
     final ports = await checkOpenPorts();
     if (!mounted) return;
     setState(() {
@@ -129,7 +129,18 @@ class _HomePageState extends State<HomePage>
             Text('デバイス情報',
                 style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
-            Text(_deviceInfo!),
+            DataTable(
+              columns: const [
+                DataColumn(label: Text('名前')),
+                DataColumn(label: Text('バージョン')),
+              ],
+              rows: _deviceInfo!
+                  .map((d) => DataRow(cells: [
+                        DataCell(Text(d.name)),
+                        DataCell(Text(d.version)),
+                      ]))
+                  .toList(),
+            ),
             const SizedBox(height: 16),
             Text('ポート開放状況',
                 style: Theme.of(context).textTheme.titleMedium),

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -1,8 +1,22 @@
 import 'dart:async';
 
-Future<String> scanDeviceVersion() async {
+/// Information returned from a device scan.
+class DeviceInfo {
+  final String name;
+  final String version;
+
+  DeviceInfo({required this.name, required this.version});
+}
+
+/// Signature for a function that performs a device version scan.
+typedef DeviceVersionScanner = Future<List<DeviceInfo>> Function();
+
+/// The actual scanner used by [deviceVersionScan].
+DeviceVersionScanner deviceVersionScan = _defaultDeviceVersionScan;
+
+Future<List<DeviceInfo>> _defaultDeviceVersionScan() async {
   await Future.delayed(const Duration(seconds: 1));
-  return 'Device version: 1.0';
+  return [DeviceInfo(name: 'Device A', version: '1.0')];
 }
 
 Future<String> checkOpenPorts() async {

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -1,8 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
+import 'package:nwcd_c/scanner.dart';
 
 void main() {
+  late DeviceVersionScanner originalScanner;
+
+  setUp(() {
+    originalScanner = deviceVersionScan;
+    deviceVersionScan = () async => [
+          DeviceInfo(name: 'Router', version: '1.2'),
+          DeviceInfo(name: 'Switch', version: '2.0'),
+        ];
+  });
+
+  tearDown(() {
+    deviceVersionScan = originalScanner;
+  });
+
   testWidgets('Full scan shows results in tab', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
@@ -21,6 +36,10 @@ void main() {
 
     expect(find.text('デバイス情報'), findsOneWidget);
     expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.text('Router'), findsOneWidget);
+    expect(find.text('1.2'), findsOneWidget);
+    expect(find.text('Switch'), findsOneWidget);
+    expect(find.text('2.0'), findsOneWidget);
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- introduce `DeviceInfo` model and `deviceVersionScan` hook
- show scan results as a table in the full-scan tab
- extend widget test with mocked scan data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6107ea588323b1070dbe04e88d66