### PR TITLE
Implement deviceVersionScan results

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -14,8 +14,7 @@ class _HomePageState extends State<HomePage>
   late final TabController _tabController;
   bool _realtimeRunning = false;
   bool _fullScanLoading = false;
-  String? _deviceInfo;
-  String? _portInfo;
+  List<DeviceInfo>? _scanResults;
   final List<String> _realtimeLogs = [];
   Timer? _realtimeTimer;
 
@@ -53,16 +52,13 @@ class _HomePageState extends State<HomePage>
   Future<void> _startFullScan() async {
     setState(() {
       _fullScanLoading = true;
-      _deviceInfo = null;
-      _portInfo = null;
+      _scanResults = null;
     });
-    final device = await scanDeviceVersion();
-    final ports = await checkOpenPorts();
+    final results = await deviceVersionScan();
     if (!mounted) return;
     setState(() {
       _fullScanLoading = false;
-      _deviceInfo = device;
-      _portInfo = ports;
+      _scanResults = results;
     });
   }
 
@@ -125,17 +121,49 @@ class _HomePageState extends State<HomePage>
           ),
           const SizedBox(height: 16),
           if (isLoading) const CircularProgressIndicator(),
-          if (!isLoading && _deviceInfo != null && _portInfo != null) ...[
-            Text('デバイス情報',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text(_deviceInfo!),
-            const SizedBox(height: 16),
-            Text('ポート開放状況',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Text(_portInfo!),
-          ],
+          if (!isLoading && _scanResults != null)
+            Expanded(
+              child: ListView(
+                children: [
+                  _buildResultRow(
+                    'OSアップデート未適用',
+                    _scanResults!
+                        .where((d) => d.osUpdatePending)
+                        .map((d) => d.name)
+                        .toList(),
+                  ),
+                  _buildResultRow(
+                    'RDPポート開放 (3389)',
+                    _scanResults!
+                        .where((d) => d.rdpOpen)
+                        .map((d) => d.name)
+                        .toList(),
+                  ),
+                  _buildResultRow(
+                    'CVE脆弱性検出あり',
+                    _scanResults!
+                        .where((d) => d.hasCve)
+                        .map((d) => d.name)
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+      );
+  }
+
+  Widget _buildResultRow(String title, List<String> devices) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 4),
+          ...devices.map(Text.new),
+          if (devices.isEmpty) const Text('-'),
         ],
       ),
     );

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -1,5 +1,20 @@
 import 'dart:async';
 
+/// Simple representation of a scanned device.
+class DeviceInfo {
+  DeviceInfo({
+    required this.name,
+    required this.osUpdatePending,
+    required this.rdpOpen,
+    required this.hasCve,
+  });
+
+  final String name;
+  final bool osUpdatePending;
+  final bool rdpOpen;
+  final bool hasCve;
+}
+
 Future<String> scanDeviceVersion() async {
   await Future.delayed(const Duration(seconds: 1));
   return 'Device version: 1.0';
@@ -8,4 +23,30 @@ Future<String> scanDeviceVersion() async {
 Future<String> checkOpenPorts() async {
   await Future.delayed(const Duration(seconds: 1));
   return 'Open ports: 80, 443';
+}
+
+/// Mock scan that returns a list of [DeviceInfo] objects.
+Future<List<DeviceInfo>> deviceVersionScan() async {
+  await Future.delayed(const Duration(seconds: 1));
+  // The returned data is static for demo purposes.
+  return [
+    DeviceInfo(
+      name: 'Device A',
+      osUpdatePending: true,
+      rdpOpen: false,
+      hasCve: true,
+    ),
+    DeviceInfo(
+      name: 'Device B',
+      osUpdatePending: false,
+      rdpOpen: true,
+      hasCve: false,
+    ),
+    DeviceInfo(
+      name: 'Device C',
+      osUpdatePending: true,
+      rdpOpen: true,
+      hasCve: true,
+    ),
+  ];
 }

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -19,8 +19,9 @@ void main() {
     await tester.pump(const Duration(seconds: 2));
     await tester.pumpAndSettle();
 
-    expect(find.text('デバイス情報'), findsOneWidget);
-    expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.text('OSアップデート未適用'), findsOneWidget);
+    expect(find.text('RDPポート開放 (3389)'), findsOneWidget);
+    expect(find.text('CVE脆弱性検出あり'), findsOneWidget);
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add `DeviceInfo` model and mock `deviceVersionScan`
- update `_startFullScan()` to collect `DeviceInfo`
- render a result list after full scan
- update widget test for new UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6107b57c83239e39379aaab84829