### PR TITLE
Implement network device version scanning

### DIFF
--- a/lib/device_info.dart
+++ b/lib/device_info.dart
@@ -1,0 +1,31 @@
+class DeviceInfo {
+  final String ip;
+  String? host;
+  String? deviceName;
+  String? osVersion;
+  List<int>? openPorts;
+  List<String>? vulnerabilities;
+
+  DeviceInfo({
+    required this.ip,
+    this.host,
+    this.deviceName,
+    this.osVersion,
+    this.openPorts,
+    this.vulnerabilities,
+  });
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('IP: $ip');
+    if (deviceName != null) buffer.write('\nDevice: $deviceName');
+    if (osVersion != null) buffer.write('\nOS: $osVersion');
+    if (openPorts != null && openPorts!.isNotEmpty) {
+      buffer.write('\nOpen ports: ${openPorts!.join(', ')}');
+    }
+    if (vulnerabilities != null && vulnerabilities!.isNotEmpty) {
+      buffer.write('\nVulnerabilities:\n  - ' + vulnerabilities!.join('\n  - '));
+    }
+    return buffer.toString();
+  }
+}

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -1,8 +1,76 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'device_info.dart';
+
+Future<List<String>> _enumerateLocalIps() async {
+  try {
+    final result = await Process.run('arp', ['-a']).timeout(const Duration(seconds: 5));
+    if (result.exitCode == 0) {
+      final regex = RegExp(r'((?:\\d{1,3}\\.){3}\\d{1,3})');
+      return regex
+          .allMatches(result.stdout.toString())
+          .map((m) => m.group(1)!)
+          .toSet()
+          .toList();
+    }
+  } catch (_) {}
+  return [];
+}
+
+Future<List<DeviceInfo>> deviceVersionScan() async {
+  final ips = await _enumerateLocalIps();
+  final devices = <DeviceInfo>[];
+  for (final ip in ips) {
+    final info = DeviceInfo(ip: ip);
+    try {
+      final nmap = await Process.run('nmap', ['-O', ip]).timeout(const Duration(seconds: 10));
+      if (nmap.exitCode == 0) {
+        final output = nmap.stdout.toString();
+        final osMatch = RegExp(r'OS details: (.*)').firstMatch(output) ??
+            RegExp(r'Running: (.*)').firstMatch(output);
+        if (osMatch != null) {
+          info.osVersion = osMatch.group(1)!.trim();
+        }
+        final portMatches = RegExp(r'^(\\d+)/tcp\\s+open', multiLine: true)
+            .allMatches(output)
+            .map((m) => int.tryParse(m.group(1)!) ?? 0)
+            .where((p) => p > 0)
+            .toList();
+        if (portMatches.isNotEmpty) info.openPorts = portMatches;
+      }
+    } catch (_) {}
+
+    if (info.osVersion != null) {
+      try {
+        final uri = Uri.parse('https://cve.circl.lu/api/search/${Uri.encodeComponent(info.osVersion!)}');
+        final request = await HttpClient().getUrl(uri).timeout(const Duration(seconds: 5));
+        final response = await request.close().timeout(const Duration(seconds: 5));
+        if (response.statusCode == 200) {
+          final body = await response.transform(utf8.decoder).join();
+          final data = json.decode(body);
+          if (data is List) {
+            info.vulnerabilities =
+                data.map<String>((e) => e['id'].toString()).take(5).toList();
+          }
+        }
+      } catch (_) {}
+    }
+
+    devices.add(info);
+  }
+  return devices;
+}
 
 Future<String> scanDeviceVersion() async {
-  await Future.delayed(const Duration(seconds: 1));
-  return 'Device version: 1.0';
+  try {
+    final devices = await deviceVersionScan();
+    if (devices.isEmpty) return 'No devices found';
+    return devices.map((d) => d.toString()).join('\n\n');
+  } catch (e) {
+    return 'Scan failed: $e';
+  }
 }
 
 Future<String> checkOpenPorts() async {


### PR DESCRIPTION
## Summary
- add `DeviceInfo` model describing hosts, ports and vulnerabilities
- implement `deviceVersionScan` using `nmap` and CVE API lookup
- update `scanDeviceVersion` to use new scanning logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b61075cec8323ae383a11d117a18e