### PR TITLE
Add device version scanning

### DIFF
--- a/cve_db.json
+++ b/cve_db.json
@@ -1,0 +1,10 @@
+{
+  "os": {
+    "Ubuntu": ["CVE-2021-1234"],
+    "Windows": ["CVE-2020-9999"]
+  },
+  "software": {
+    "Apache": ["CVE-2022-0001"],
+    "OpenSSH": ["CVE-2019-2034"]
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -59,7 +59,8 @@ class _HomePageState extends State<HomePage>
       _deviceInfo = null;
       _portInfo = null;
     });
-    final device = await scanDeviceVersion();
+    final info = await deviceVersionScan('127.0.0.1');
+    final device = info.toString();
     final ports = await checkOpenPorts();
     if (!mounted) return;
     setState(() {

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -1,4 +1,41 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Basic device version information discovered during scans.
+class DeviceVersionInfo {
+  final String osVersion;
+  final String firmwareVersion;
+  final List<String> softwareVersions;
+  final List<String> cveMatches;
+
+  DeviceVersionInfo({
+    required this.osVersion,
+    required this.firmwareVersion,
+    required this.softwareVersions,
+    required this.cveMatches,
+  });
+
+  @override
+  String toString() {
+    final buffer = StringBuffer();
+    buffer.writeln('OS: $osVersion');
+    buffer.writeln('Firmware: $firmwareVersion');
+    if (softwareVersions.isNotEmpty) {
+      buffer.writeln('Software:');
+      for (final s in softwareVersions) {
+        buffer.writeln('  - $s');
+      }
+    }
+    if (cveMatches.isNotEmpty) {
+      buffer.writeln('Possible CVEs:');
+      for (final cve in cveMatches) {
+        buffer.writeln('  - $cve');
+      }
+    }
+    return buffer.toString().trim();
+  }
+}
 
 Future<String> scanDeviceVersion() async {
   await Future.delayed(const Duration(seconds: 1));
@@ -8,4 +45,87 @@ Future<String> scanDeviceVersion() async {
 Future<String> checkOpenPorts() async {
   await Future.delayed(const Duration(seconds: 1));
   return 'Open ports: 80, 443';
+}
+
+/// Scan a device at [ip] using `nmap` to gather version information.
+///
+/// The returned data includes detected operating system, firmware (if any),
+/// discovered service versions and possible CVE matches from a local JSON
+/// database. If `nmap` is unavailable, placeholder values are returned.
+Future<DeviceVersionInfo> deviceVersionScan(String ip) async {
+  try {
+    final result = await Process.run('nmap', ['-O', '-sV', ip]);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'nmap',
+        ['-O', '-sV', ip],
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
+    final output = result.stdout as String;
+
+    final osMatch = RegExp(r'OS details: ([^\n]+)').firstMatch(output);
+    final osVersion = osMatch?.group(1) ?? 'Unknown';
+
+    // Firmware version is rarely exposed; look for a common pattern.
+    final firmwareMatch = RegExp(r'Firmware Version: ([^\n]+)').firstMatch(output);
+    final firmwareVersion = firmwareMatch?.group(1) ?? 'Unknown';
+
+    final softwareVersions = <String>[];
+    for (final line in LineSplitter.split(output)) {
+      final match = RegExp(r'^\\d+/\\w+\\s+open\\s+[^\\s]+\\s+(.+)\\$').firstMatch(line.trim());
+      if (match != null) {
+        softwareVersions.add(match.group(1)!.trim());
+      }
+    }
+
+    final cveMatches = await _lookupCves(osVersion, softwareVersions);
+
+    return DeviceVersionInfo(
+      osVersion: osVersion,
+      firmwareVersion: firmwareVersion,
+      softwareVersions: softwareVersions,
+      cveMatches: cveMatches,
+    );
+  } catch (_) {
+    return DeviceVersionInfo(
+      osVersion: 'Unknown',
+      firmwareVersion: 'Unknown',
+      softwareVersions: const [],
+      cveMatches: const [],
+    );
+  }
+}
+
+Future<List<String>> _lookupCves(
+  String osVersion,
+  List<String> softwareVersions,
+) async {
+  final file = File('cve_db.json');
+  if (!await file.exists()) return [];
+  try {
+    final jsonData = json.decode(await file.readAsString()) as Map<String, dynamic>;
+    final matches = <String>[];
+
+    final osMap = jsonData['os'] as Map<String, dynamic>? ?? {};
+    for (final entry in osMap.entries) {
+      if (osVersion.contains(entry.key)) {
+        matches.addAll(List<String>.from(entry.value as List));
+      }
+    }
+
+    final swMap = jsonData['software'] as Map<String, dynamic>? ?? {};
+    for (final sw in softwareVersions) {
+      for (final entry in swMap.entries) {
+        if (sw.contains(entry.key)) {
+          matches.addAll(List<String>.from(entry.value as List));
+        }
+      }
+    }
+
+    return matches.toSet().toList();
+  } catch (_) {
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- introduce `DeviceVersionInfo` model and `deviceVersionScan` helper
- optional CVE lookup from `cve_db.json`
- surface device version scanning in the full scan workflow

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b71738c588323bc2a448deb458667