### PR TITLE
Add vulnerability table to full scan

### DIFF
--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 
 void main() {
-  testWidgets('Full scan shows results in tab', (WidgetTester tester) async {
+  testWidgets('Full scan shows table results', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
     // Navigate to full scan tab
@@ -19,8 +19,9 @@ void main() {
     await tester.pump(const Duration(seconds: 2));
     await tester.pumpAndSettle();
 
-    expect(find.text('デバイス情報'), findsOneWidget);
-    expect(find.text('ポート開放状況'), findsOneWidget);
+    expect(find.byType(DataTable), findsOneWidget);
+    expect(find.text('OSアップデート未適用'), findsOneWidget);
+    expect(find.text('CVE脆弱性検出あり'), findsOneWidget);
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- extend `HomePage` full scan tab with scrollable table output
- display OS update and CVE detection status per device
- adjust widget test for new table

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b74a24a548323aedcfa36f2e965ce