### PR TITLE
Add deviceVersionScan tests

### DIFF
--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -52,9 +52,13 @@ Future<String> checkOpenPorts() async {
 /// The returned data includes detected operating system, firmware (if any),
 /// discovered service versions and possible CVE matches from a local JSON
 /// database. If `nmap` is unavailable, placeholder values are returned.
-Future<DeviceVersionInfo> deviceVersionScan(String ip) async {
+Future<DeviceVersionInfo> deviceVersionScan(
+  String ip, {
+  Future<ProcessResult> Function(String, List<String>)? runProcess,
+}) async {
   try {
-    final result = await Process.run('nmap', ['-O', '-sV', ip]);
+    final exec = runProcess ?? Process.run;
+    final result = await exec('nmap', ['-O', '-sV', ip]);
     if (result.exitCode != 0) {
       throw ProcessException(
         'nmap',

--- a/test/device_version_scan_test.dart
+++ b/test/device_version_scan_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/scanner.dart';
+
+void main() {
+  group('deviceVersionScan parsing', () {
+    test('parses nmap output for versions and CVEs', () async {
+      const sampleOutput = '''
+Nmap scan report for 127.0.0.1
+Host is up (0.00013s latency).
+OS details: Ubuntu 20.04 LTS
+Firmware Version: 1.2.3
+
+PORT   STATE SERVICE VERSION
+22/tcp open ssh OpenSSH 7.6
+80/tcp open http Apache httpd 2.4.29
+''';
+      final result = await deviceVersionScan(
+        '127.0.0.1',
+        runProcess: (_, __) async => ProcessResult(0, 0, sampleOutput, ''),
+      );
+
+      expect(result.osVersion, 'Ubuntu 20.04 LTS');
+      expect(result.firmwareVersion, '1.2.3');
+      expect(result.softwareVersions, contains('OpenSSH 7.6'));
+      expect(result.softwareVersions, contains('Apache httpd 2.4.29'));
+      // Should find CVEs for Ubuntu, Apache and OpenSSH from cve_db.json
+      expect(result.cveMatches, contains('CVE-2021-1234'));
+      expect(result.cveMatches, contains('CVE-2022-0001'));
+      expect(result.cveMatches, contains('CVE-2019-2034'));
+    });
+
+    test('returns unknown when process fails', () async {
+      final result = await deviceVersionScan(
+        '127.0.0.1',
+        runProcess: (_, __) async => throw ProcessException('nmap', []),
+      );
+      expect(result.osVersion, 'Unknown');
+      expect(result.firmwareVersion, 'Unknown');
+      expect(result.softwareVersions, isEmpty);
+      expect(result.cveMatches, isEmpty);
+    });
+  });
+}

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -22,6 +22,10 @@ void main() {
     expect(find.byType(DataTable), findsOneWidget);
     expect(find.text('OSアップデート未適用'), findsOneWidget);
     expect(find.text('CVE脆弱性検出あり'), findsOneWidget);
+    // Row information should include scan results
+    expect(find.text('127.0.0.1'), findsOneWidget);
+    expect(find.text('Yes'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- inject a custom process runner for `deviceVersionScan`
- add unit tests checking parsing logic
- expect scan results in home page widget test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b76acf9b48323ad67c0a48dccee94