### PR TITLE
Add network topology graph

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  graphview: ^1.2.3
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add `graphview` dependency
- implement topology gathering in `network_scanner.dart`
- render a simple network graph in the network diagram tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9f7a748c832395cfde3ea96a21b0