### PR TITLE
Add port scanning functionality

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -7,11 +7,13 @@ class FullScanResult {
   final String target;
   final bool osOutdated;
   final bool hasCve;
+  final String openPorts;
 
   FullScanResult({
     required this.target,
     required this.osOutdated,
     required this.hasCve,
+    required this.openPorts,
   });
 }
 
@@ -70,11 +72,12 @@ class _HomePageState extends State<HomePage>
       _fullScanResults = null;
     });
     final info = await deviceVersionScan('127.0.0.1');
-    await checkOpenPorts();
+    final portInfo = await checkOpenPorts('127.0.0.1');
     final result = FullScanResult(
       target: '127.0.0.1',
       osOutdated: info.osVersion == 'Unknown',
       hasCve: info.cveMatches.isNotEmpty,
+      openPorts: portInfo,
     );
     if (!mounted) return;
     setState(() {
@@ -165,6 +168,7 @@ class _HomePageState extends State<HomePage>
                     DataColumn(label: Text('IP/デバイス')),
                     DataColumn(label: Text('OSアップデート未適用')),
                     DataColumn(label: Text('CVE脆弱性検出あり')),
+                    DataColumn(label: Text('開放ポート')),
                   ],
                   rows: results
                       .map(
@@ -172,6 +176,7 @@ class _HomePageState extends State<HomePage>
                           DataCell(Text(r.target)),
                           DataCell(Text(r.osOutdated ? 'Yes' : 'No')),
                           DataCell(Text(r.hasCve ? 'Yes' : 'No')),
+                          DataCell(Text(r.openPorts)),
                         ]),
                       )
                       .toList(),

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -22,6 +22,7 @@ void main() {
     expect(find.byType(DataTable), findsOneWidget);
     expect(find.text('OSアップデート未適用'), findsOneWidget);
     expect(find.text('CVE脆弱性検出あり'), findsOneWidget);
+    expect(find.text('開放ポート'), findsOneWidget);
     // Row information should include scan results
     expect(find.text('127.0.0.1'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);


### PR DESCRIPTION
## Summary
- implement basic port scan in `checkOpenPorts` using nmap or socket fallback
- store and display open port info in the full scan table
- extend home page UI and result data model with open port column
- update widget test for new column

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba4aab83483239f0c827a388004e8