### PR TITLE
Fix regex parsing for device version scan

### DIFF
--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -120,7 +120,7 @@ Future<DeviceVersionInfo> deviceVersionScan(
 
     final softwareVersions = <String>[];
     for (final line in LineSplitter.split(output)) {
-      final match = RegExp(r'^\\d+/\\w+\\s+open\\s+[^\\s]+\\s+(.+)\\$').firstMatch(line.trim());
+      final match = RegExp(r'^\d+/\w+\s+open\s+[^\s]+\s+(.+)$').firstMatch(line.trim());
       if (match != null) {
         softwareVersions.add(match.group(1)!.trim());
       }


### PR DESCRIPTION
## Summary
- correct pattern when extracting software info from nmap output

## Testing
- `flutter test test/device_version_scan_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_687e3bd8303c8323beca03b59c524bc5