### PR TITLE
Add contribution setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thank you for considering contributing to **nwcd_c**!
+
+## Setup
+
+1. Install [Flutter](https://docs.flutter.dev/) **3.29.2**, which ships with Dart **3.7.2**.
+   Use `flutter --version` to verify the installed versions.
+2. Clone this repository and fetch dependencies:
+
+   ```bash
+   flutter pub get
+   ```
+
+## Running tests
+
+Execute the test suite from the project root with:
+
+```bash
+flutter test
+```
+
+This command uses Flutter's built-in test runner.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Pressing either scan button shows a short progress indicator. Once the
 actual scanning logic is implemented, each workflow will navigate to a results
 page summarizing the findings.
 
+## Setup
+
+This project targets **Flutter 3.29.2** with **Dart 3.7.2**. After installing
+Flutter, fetch dependencies with:
+
+```bash
+flutter pub get
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for additional details.
+
 ## Workflows
 
 ### Real-time scan


### PR DESCRIPTION
## Summary
- document how to set up Flutter and run tests
- link to CONTRIBUTING from README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3bd948988323865337f6e0829ec5