### PR TITLE
Add network diagram widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for additional details.
 
 ### Network diagram
 1. Tap **ネットワーク図** on the home screen.
-2. A placeholder diagram is displayed showing where network visuals will appear.
+2. After the scan finishes a simple graph of detected devices is shown.
 
 **Note:** Only run network scans against systems you are authorized to test.
 Unauthorized scanning can be illegal or violate terms of service.

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'scanner.dart';
 import 'network_scanner.dart';
+import 'network_diagram.dart';
 
 class FullScanResult {
   final String target;
@@ -18,7 +19,9 @@ class FullScanResult {
 }
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  final Future<List<NetworkDevice>> Function()? scanNetworkFn;
+
+  const HomePage({super.key, this.scanNetworkFn});
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -91,7 +94,8 @@ class _HomePageState extends State<HomePage>
       _networkScanLoading = true;
       _networkDevices = null;
     });
-    final devices = await scanNetwork();
+    final scan = widget.scanNetworkFn ?? scanNetwork;
+    final devices = await scan();
     if (!mounted) return;
     setState(() {
       _networkScanLoading = false;
@@ -203,27 +207,7 @@ class _HomePageState extends State<HomePage>
           if (isLoading) const CircularProgressIndicator(),
           if (!isLoading && devices != null)
             Expanded(
-              child: SingleChildScrollView(
-                scrollDirection: Axis.vertical,
-                child: DataTable(
-                  columns: const [
-                    DataColumn(label: Text('IPアドレス')),
-                    DataColumn(label: Text('MACアドレス')),
-                    DataColumn(label: Text('ベンダー名')),
-                    DataColumn(label: Text('機器名')),
-                  ],
-                  rows: devices
-                      .map(
-                        (d) => DataRow(cells: [
-                          DataCell(Text(d.ip)),
-                          DataCell(Text(d.mac)),
-                          DataCell(Text(d.vendor)),
-                          DataCell(Text(d.name)),
-                        ]),
-                      )
-                      .toList(),
-                ),
-              ),
+              child: NetworkDiagram(devices: devices),
             ),
         ],
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'home_page.dart';
+import 'network_scanner.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final Future<List<NetworkDevice>> Function()? networkScanFn;
+
+  const MyApp({super.key, this.networkScanFn});
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const HomePage(),
+      home: HomePage(scanNetworkFn: networkScanFn),
     );
   }
 }

--- a/lib/network_diagram.dart
+++ b/lib/network_diagram.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+import 'network_scanner.dart';
+
+/// Displays a simple star topology graph of the discovered [devices].
+class NetworkDiagram extends StatelessWidget {
+  final List<NetworkDevice> devices;
+
+  const NetworkDiagram({super.key, required this.devices});
+
+  @override
+  Widget build(BuildContext context) {
+    final graph = Graph()..isTree = true;
+    final root = Node.Id('Local');
+    graph.addNode(root);
+    for (final d in devices) {
+      final label = d.name.isNotEmpty ? d.name : d.ip;
+      final node = Node.Id(label);
+      graph.addNode(node);
+      graph.addEdge(root, node);
+    }
+
+    final builder = BuchheimWalkerConfiguration()
+      ..siblingSeparation = 20
+      ..levelSeparation = 30
+      ..subtreeSeparation = 30
+      ..orientation = BuchheimWalkerConfiguration.ORIENTATION_TOP_BOTTOM;
+
+    return InteractiveViewer(
+      boundaryMargin: const EdgeInsets.all(20),
+      minScale: 0.01,
+      maxScale: 5,
+      child: GraphView(
+        graph: graph,
+        algorithm: BuchheimWalkerAlgorithm(builder, TreeEdgeRenderer(builder)),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  graphview:
+    dependency: "direct main"
+    description:
+      name: graphview
+      sha256: bdba183583b23c30c71edea09ad5f0beef612572d3e39e855467a925bd08392f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  graphview: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
+import 'package:nwcd_c/network_scanner.dart';
+import 'package:nwcd_c/network_diagram.dart';
 
 void main() {
   testWidgets('Full scan shows table results', (WidgetTester tester) async {
@@ -28,5 +30,32 @@ void main() {
     expect(find.text('Yes'), findsOneWidget);
     expect(find.text('No'), findsOneWidget);
     expect(find.text('フルスキャン開始'), findsOneWidget);
+  });
+
+  testWidgets('Network scan displays diagram', (WidgetTester tester) async {
+    Future<List<NetworkDevice>> fakeScan() async {
+      return [
+        NetworkDevice(
+          ip: '192.168.1.2',
+          mac: '00:11:22:33:44:55',
+          vendor: 'TestVendor',
+          name: 'Device1',
+        ),
+      ];
+    }
+
+    await tester.pumpWidget(MyApp(networkScanFn: fakeScan));
+
+    await tester.tap(find.widgetWithText(Tab, 'ネットワーク図'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('ネットワークスキャン開始'));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NetworkDiagram), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement `NetworkDiagram` widget using `graphview`
- inject a network scan function into `HomePage` and `MyApp`
- show `NetworkDiagram` after scanning
- document diagram feature
- test that the diagram displays

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4334907c83239303098ac96694a1