### PR TITLE
Add tests for checkOpenPorts

### DIFF
--- a/test/check_open_ports_test.dart
+++ b/test/check_open_ports_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/scanner.dart';
+
+void main() {
+  test('parses nmap output for open ports', () async {
+    const sample = '22/tcp open ssh\n80/tcp open http';
+    final result = await checkOpenPorts(
+      '127.0.0.1',
+      runProcess: (_, __) async => ProcessResult(0, 0, sample, ''),
+    );
+    expect(result, 'Open ports: 22, 80');
+  });
+
+  test('falls back to socket scan on ProcessException', () async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    final result = await checkOpenPorts(
+      '127.0.0.1',
+      runProcess: (_, __) async => throw ProcessException('nmap', []),
+      ports: [server.port],
+    );
+    await server.close();
+    expect(result, 'Open ports: ${server.port}');
+  });
+}


### PR DESCRIPTION
## Summary
- inject dependencies into `checkOpenPorts`
- add tests covering `checkOpenPorts`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e48784ca0832386e358b6b045aa8d