### PR TITLE
Improve port scan feedback

### DIFF
--- a/test/check_open_ports_test.dart
+++ b/test/check_open_ports_test.dart
@@ -22,4 +22,13 @@ void main() {
     await server.close();
     expect(result, 'Open ports: ${server.port}');
   });
+  test('returns failure message when scan cannot be performed', () async {
+    final result = await checkOpenPorts(
+      '127.0.0.1',
+      runProcess: (_, __) async => throw ProcessException('nmap', []),
+      socketConnect: (_, __, {timeout}) async => throw SocketException('fail'),
+    );
+    expect(result, 'Scan failed');
+  });
+
 }


### PR DESCRIPTION
## Summary
- detect failed scans in `checkOpenPorts`
- add test for failure case

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c687d908323842229c24d7ee1bc