### PR TITLE
Fix runProcess error in scanner

### DIFF
--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -2,6 +2,10 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+/// Signature for a function that runs a process and returns the result.
+typedef ProcessRunner = Future<ProcessResult> Function(
+    String executable, List<String> arguments);
+
 /// Basic device version information discovered during scans.
 class DeviceVersionInfo {
   final String osVersion;
@@ -96,7 +100,7 @@ Future<String> checkOpenPorts([String ip = '127.0.0.1']) async {
 /// database. If `nmap` is unavailable, placeholder values are returned.
 Future<DeviceVersionInfo> deviceVersionScan(
   String ip, {
-  Future<ProcessResult> Function(String, List<String>)? runProcess,
+  ProcessRunner? runProcess,
 }) async {
   try {
     final exec = runProcess ?? Process.run;


### PR DESCRIPTION
## Summary
- define `ProcessRunner` typedef
- use the new typedef in `deviceVersionScan`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e544f10288323b94876d92b8e763d