### PR TITLE
Limit ping sweep on large networks

### DIFF
--- a/lib/network_scanner.dart
+++ b/lib/network_scanner.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:meta/meta.dart';
 
 class NetworkDevice {
   final String ip;
@@ -97,24 +98,53 @@ List<NetworkDevice> _parseNmapOutput(String output) {
   return devices;
 }
 
-Future<List<NetworkDevice>> _pingSweep(String subnet) async {
+Future<List<NetworkDevice>> _pingSweep(
+  String subnet, {
+  Future<void> Function(String ip)? pingAddress,
+  Future<List<NetworkDevice>> Function()? readArpTable,
+  int maxHosts = 1024,
+}) async {
   final parts = subnet.split('/');
   if (parts.length != 2) return [];
   final baseIp = parts[0];
   final prefix = int.tryParse(parts[1]!) ?? 24;
   final start = _ipToInt(calculateNetwork(baseIp, prefix));
   final count = 1 << (32 - prefix);
+  final hostCount = count - 2;
+  if (hostCount <= 0) return [];
+
+  final toScan = hostCount > maxHosts ? maxHosts : hostCount;
+  if (hostCount > maxHosts) {
+    stderr.writeln(
+        'Subnet $subnet has $hostCount hosts, scanning first $maxHosts only');
+  }
+
+  final ping = pingAddress ?? _pingAddress;
   final tasks = <Future<void>>[];
-  for (var i = 1; i < count - 1; i++) {
-    tasks.add(_pingAddress(_intToIp(start + i)));
+  for (var i = 1; i <= toScan; i++) {
+    tasks.add(ping(_intToIp(start + i)));
   }
   await Future.wait(tasks);
-  final arpEntries = await _readArpTable();
+  final arpEntries = await (readArpTable ?? _readArpTable)();
   return arpEntries.where((e) {
     final ipInt = _ipToInt(e.ip);
     return ipInt >= start && ipInt < start + count;
   }).toList();
 }
+
+@visibleForTesting
+Future<List<NetworkDevice>> pingSweepForTest(
+  String subnet, {
+  Future<void> Function(String ip)? pingAddress,
+  Future<List<NetworkDevice>> Function()? readArpTable,
+  int maxHosts = 1024,
+}) =>
+    _pingSweep(
+      subnet,
+      pingAddress: pingAddress,
+      readArpTable: readArpTable,
+      maxHosts: maxHosts,
+    );
 
 Future<void> _pingAddress(String ip) async {
   try {

--- a/test/network_scanner_test.dart
+++ b/test/network_scanner_test.dart
@@ -11,4 +11,27 @@ void main() {
     expect(calculateNetwork('192.168.1.5', 24), '192.168.1.0');
     expect(calculateNetwork('10.0.1.50', 16), '10.0.0.0');
   });
+
+  test('pingSweepForTest limits large networks', () async {
+    final pinged = <String>[];
+    await pingSweepForTest(
+      '192.168.0.0/16',
+      pingAddress: (ip) async => pinged.add(ip),
+      readArpTable: () async => <NetworkDevice>[],
+      maxHosts: 10,
+    );
+    expect(pinged.length, 10);
+    expect(pinged.first, '192.168.0.1');
+    expect(pinged.last, '192.168.0.10');
+  });
+
+  test('pingSweepForTest scans full range when small', () async {
+    final pinged = <String>[];
+    await pingSweepForTest(
+      '10.0.0.0/30',
+      pingAddress: (ip) async => pinged.add(ip),
+      readArpTable: () async => <NetworkDevice>[],
+    );
+    expect(pinged, ['10.0.0.1', '10.0.0.2']);
+  });
 }


### PR DESCRIPTION
## Summary
- avoid unbounded scans by capping `_pingSweep` to a configurable host limit
- expose `pingSweepForTest` helper for unit tests
- add unit tests for the ping sweep host limit

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e57d4b0b483239a0f2318a1eb2f7e