### PR TITLE
Gracefully handle missing external tools

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -95,18 +95,26 @@ class _HomePageState extends State<HomePage>
       _fullScanResults = null;
     });
     final info = await deviceVersionScan(_fullScanIp);
-    final portInfo = await checkOpenPorts(_fullScanIp);
+    final portResult = await checkOpenPorts(_fullScanIp);
     final result = FullScanResult(
       target: _fullScanIp,
       osOutdated: info.osVersion == 'Unknown',
       hasCve: info.cveMatches.isNotEmpty,
-      openPorts: portInfo,
+      openPorts: portResult.result,
     );
     if (!mounted) return;
     setState(() {
       _fullScanLoading = false;
       _fullScanResults = [result];
     });
+    if (info.error != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(info.error!)));
+    }
+    if (portResult.error != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(portResult.error!)));
+    }
   }
 
   Future<void> _startNetworkScan() async {
@@ -114,12 +122,16 @@ class _HomePageState extends State<HomePage>
       _networkScanLoading = true;
       _networkDevices = null;
     });
-    final devices = await scanNetwork();
+    final result = await scanNetwork();
     if (!mounted) return;
     setState(() {
       _networkScanLoading = false;
-      _networkDevices = devices;
+      _networkDevices = result.devices;
     });
+    if (result.error != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(result.error!)));
+    }
   }
 
   @override

--- a/test/check_open_ports_test.dart
+++ b/test/check_open_ports_test.dart
@@ -9,7 +9,8 @@ void main() {
       '127.0.0.1',
       runProcess: (_, __) async => ProcessResult(0, 0, sample, ''),
     );
-    expect(result, 'Open ports: 22, 80');
+    expect(result.result, 'Open ports: 22, 80');
+    expect(result.error, isNull);
   });
 
   test('falls back to socket scan on ProcessException', () async {
@@ -20,7 +21,8 @@ void main() {
       ports: [server.port],
     );
     await server.close();
-    expect(result, 'Open ports: ${server.port}');
+    expect(result.result, 'Open ports: ${server.port}');
+    expect(result.error, 'nmap command not found');
   });
   test('returns failure message when scan cannot be performed', () async {
     final result = await checkOpenPorts(
@@ -28,7 +30,8 @@ void main() {
       runProcess: (_, __) async => throw ProcessException('nmap', []),
       socketConnect: (_, __, {timeout}) async => throw SocketException('fail'),
     );
-    expect(result, 'Scan failed');
+    expect(result.result, 'Scan failed');
+    expect(result.error, 'nmap command not found');
   });
 
 }

--- a/test/device_version_scan_test.dart
+++ b/test/device_version_scan_test.dart
@@ -39,6 +39,7 @@ PORT   STATE SERVICE VERSION
       expect(result.firmwareVersion, 'Unknown');
       expect(result.softwareVersions, isEmpty);
       expect(result.cveMatches, isEmpty);
+      expect(result.error, 'nmap command not found');
     });
   });
 }


### PR DESCRIPTION
## Summary
- introduce `NetworkScanResult`, `SubnetsResult`, and `PortScanResult`
- report missing command errors from `nmap`, `ip`, `ifconfig` and `arp`
- surface errors in `HomePage` via snackbars
- update tests for new return types

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e59ee1e3c8323a9a5040ff1ed8a57