### PR TITLE
Fix checkOpenPorts parameter syntax

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -95,7 +95,7 @@ class _HomePageState extends State<HomePage>
       _fullScanResults = null;
     });
     final info = await deviceVersionScan(_fullScanIp);
-    final portResult = await checkOpenPorts(_fullScanIp);
+    final portResult = await checkOpenPorts(ip: _fullScanIp);
     final result = FullScanResult(
       target: _fullScanIp,
       osOutdated: info.osVersion == 'Unknown',

--- a/lib/scanner.dart
+++ b/lib/scanner.dart
@@ -62,12 +62,12 @@ Future<String> scanDeviceVersion() async {
 /// function falls back to attempting socket connections to a small set of
 /// frequently used ports. The returned string lists the detected open ports or
 /// `No open ports` when none are found or the scan fails.
-Future<PortScanResult> checkOpenPorts([
-  String ip = '127.0.0.1', {
+Future<PortScanResult> checkOpenPorts({
+  String ip = '127.0.0.1',
   Future<ProcessResult> Function(String, List<String>)? runProcess,
   Future<Socket> Function(String, int, {Duration? timeout})? socketConnect,
   List<int>? ports,
-}]) async {
+}) async {
   final openPorts = <int>[];
   bool success = false;
   String? error;
@@ -102,11 +102,11 @@ Future<PortScanResult> checkOpenPorts([
               timeout: const Duration(milliseconds: 500));
           socket.destroy();
           openPorts.add(port);
+          success = true;
         } catch (_) {
-          // closed
+          // closed or unreachable
         }
       }
-      success = true;
     } catch (_) {
       // Socket scanning failed
     }

--- a/test/check_open_ports_test.dart
+++ b/test/check_open_ports_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('parses nmap output for open ports', () async {
     const sample = '22/tcp open ssh\n80/tcp open http';
     final result = await checkOpenPorts(
-      '127.0.0.1',
+      ip: '127.0.0.1',
       runProcess: (_, __) async => ProcessResult(0, 0, sample, ''),
     );
     expect(result.result, 'Open ports: 22, 80');
@@ -16,7 +16,7 @@ void main() {
   test('falls back to socket scan on ProcessException', () async {
     final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
     final result = await checkOpenPorts(
-      '127.0.0.1',
+      ip: '127.0.0.1',
       runProcess: (_, __) async => throw ProcessException('nmap', []),
       ports: [server.port],
     );
@@ -26,7 +26,7 @@ void main() {
   });
   test('returns failure message when scan cannot be performed', () async {
     final result = await checkOpenPorts(
-      '127.0.0.1',
+      ip: '127.0.0.1',
       runProcess: (_, __) async => throw ProcessException('nmap', []),
       socketConnect: (_, __, {timeout}) async => throw SocketException('fail'),
     );


### PR DESCRIPTION
## Summary
- fix `checkOpenPorts` parameter syntax by using named arguments
- update calls in `home_page.dart` and associated tests
- make socket scanning mark success only after a successful connection

## Testing
- `flutter test` *(fails: Full scan shows table results)*

------
https://chatgpt.com/codex/tasks/task_e_687eec647a4883238d38bab3a0e98ce4