### PR TITLE
Fix syntax for network diagram widget

### DIFF
--- a/lib/network_diagram.dart
+++ b/lib/network_diagram.dart
@@ -4,9 +4,21 @@ import 'network_scanner.dart';
 
 /// Displays a simple star topology graph of the discovered [devices].
 class NetworkDiagram extends StatelessWidget {
+  /// Devices displayed in the diagram.
   final List<NetworkDevice> devices;
 
-  const NetworkDiagram({super.key, required this.devices});
+  /// Optional width for the diagram. Specify when a fixed size is required.
+  final double? width;
+
+  /// Optional height for the diagram. Specify when a fixed size is required.
+  final double? height;
+
+  const NetworkDiagram({
+    super.key,
+    required this.devices,
+    this.width,
+    this.height,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -26,24 +38,30 @@ class NetworkDiagram extends StatelessWidget {
       ..subtreeSeparation = 30
       ..orientation = BuchheimWalkerConfiguration.ORIENTATION_TOP_BOTTOM;
 
+    Widget graphWidget = GraphView(
+      graph: graph,
+      algorithm: BuchheimWalkerAlgorithm(layout, TreeEdgeRenderer(layout)),
+      builder: (Node node) {
+        final id = node.key?.value ?? '';
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text('$id'),
+          ),
+        );
+      },
+    );
+
+    if (width != null || height != null) {
+      graphWidget = SizedBox(width: width, height: height, child: graphWidget);
+    }
+
     return InteractiveViewer(
       constrained: false,
       boundaryMargin: const EdgeInsets.all(20),
       minScale: 0.01,
       maxScale: 5,
-      child: GraphView(
-        graph: graph,
-        algorithm: BuchheimWalkerAlgorithm(layout, TreeEdgeRenderer(layout)),
-        builder: (Node node) {
-          final id = node.key?.value ?? '';
-          return Card(
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text('$id'),
-            ),
-          );
-        },
-      ),
+      child: graphWidget,
     );
   }
 }


### PR DESCRIPTION
## Summary
- correct mis-placed parenthesis in `NetworkDiagram`
- keep interactive viewer unconstrained and allow optional sizing via `SizedBox`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802a7669f4832389bb2bd5659406c0