### PR TITLE
Fix duplicate errors for port scans

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -90,7 +90,7 @@ class _HomePageState extends State<HomePage>
     }
 
     final results = <FullScanResult>[];
-    final errors = <String>[];
+    final errors = <String>{};
 
     for (final ip in ips) {
       final info = await deviceVersionScan(ip);


### PR DESCRIPTION
## Summary
- deduplicate errors when running full scans so repeated messages only appear once

## Testing
- `dart --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688049ed88c48323bfbc4d6f7246358b