### PR TITLE
Fix import for network scanner

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'scanner.dart';
-import 'network_scanner.dart';
+import 'package:nwcd_c/scanner.dart';
+import 'package:nwcd_c/network_scanner.dart';
 
 class FullScanResult {
   final String target;


### PR DESCRIPTION
## Summary
- use package imports for `network_scanner.dart` and `scanner.dart`

## Testing
- `apt-get update` *(fails to reach mise.jdx.dev)*

------
https://chatgpt.com/codex/tasks/task_e_68804e7810688323b35386de059f3ee8