### PR TITLE
Add topology scanning using LLDP

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,8 +8,9 @@ void main() {
 
 class MyApp extends StatelessWidget {
   final Future<List<NetworkDevice>> Function()? networkScanFn;
+  final Future<List<TopologyLink>> Function()? topologyScanFn;
 
-  const MyApp({super.key, this.networkScanFn});
+  const MyApp({super.key, this.networkScanFn, this.topologyScanFn});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +19,10 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: HomePage(scanNetworkFn: networkScanFn),
+      home: HomePage(
+        scanNetworkFn: networkScanFn,
+        scanTopologyFn: topologyScanFn,
+      ),
     );
   }
 }

--- a/lib/network_diagram.dart
+++ b/lib/network_diagram.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:graphview/GraphView.dart';
 import 'network_scanner.dart';
+import 'topology_scanner.dart';
 
 /// Displays a simple star topology graph of the discovered [devices].
 class NetworkDiagram extends StatelessWidget {
   /// Devices displayed in the diagram.
   final List<NetworkDevice> devices;
+
+  /// Optional topology describing how devices are connected. If empty,
+  /// a star topology anchored at "Local" is used.
+  final List<TopologyLink> topology;
 
   /// Optional width for the diagram. Specify when a fixed size is required.
   final double? width;
@@ -16,20 +21,30 @@ class NetworkDiagram extends StatelessWidget {
   const NetworkDiagram({
     super.key,
     required this.devices,
+    this.topology = const [],
     this.width,
     this.height,
   });
 
   @override
   Widget build(BuildContext context) {
-    final graph = Graph()..isTree = true;
-    final root = Node.Id('Local');
-    graph.addNode(root);
-    for (final d in devices) {
-      final label = d.name.isNotEmpty ? d.name : d.ip;
-      final node = Node.Id(label);
-      graph.addNode(node);
-      graph.addEdge(root, node);
+    final graph = Graph();
+    final nodes = <String, Node>{};
+
+    Node getNode(String id) {
+      return nodes.putIfAbsent(id, () => Node.Id(id));
+    }
+
+    if (topology.isEmpty) {
+      final root = getNode('Local');
+      for (final d in devices) {
+        final label = d.name.isNotEmpty ? d.name : d.ip;
+        graph.addEdge(root, getNode(label));
+      }
+    } else {
+      for (final link in topology) {
+        graph.addEdge(getNode(link.from), getNode(link.to));
+      }
     }
 
     final layout = BuchheimWalkerConfiguration()
@@ -50,18 +65,6 @@ class NetworkDiagram extends StatelessWidget {
           ),
         );
       },
-    );
-
-    if (width != null || height != null) {
-      graphWidget = SizedBox(width: width, height: height, child: graphWidget);
-    }
-
-    return InteractiveViewer(
-      constrained: false,
-      boundaryMargin: const EdgeInsets.all(20),
-      minScale: 0.01,
-      maxScale: 5,
-      child: graphWidget,
     );
 
     if (width != null || height != null) {

--- a/lib/topology_scanner.dart
+++ b/lib/topology_scanner.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+/// Represents a connection from [from] interface/device to [to] device.
+class TopologyLink {
+  final String from;
+  final String to;
+
+  TopologyLink({required this.from, required this.to});
+}
+
+/// Attempts to discover network topology using the `lldpctl` command.
+///
+/// Returns a list of [TopologyLink] describing the connections. If `lldpctl`
+/// is not available or fails, an empty list is returned.
+Future<List<TopologyLink>> scanTopology({
+  Future<ProcessResult> Function()? runLldpctl,
+}) async {
+  final run = runLldpctl ?? () => Process.run('lldpctl', []);
+  try {
+    final result = await run();
+    if (result.exitCode != 0) return [];
+    return _parseLldpctl(result.stdout as String);
+  } catch (_) {
+    return [];
+  }
+}
+
+/// Parses output from `lldpctl` into a list of [TopologyLink].
+List<TopologyLink> _parseLldpctl(String output) {
+  final links = <TopologyLink>[];
+  String? currentInterface;
+  for (final line in output.split('\\n')) {
+    final trimmed = line.trim();
+    final interfaceMatch = RegExp(r'^Interface:\s*([^,]+)').firstMatch(trimmed);
+    if (interfaceMatch != null) {
+      currentInterface = interfaceMatch.group(1)!.trim();
+      continue;
+    }
+    final sysNameMatch = RegExp(r'^SysName:\s*(.+)\$').firstMatch(trimmed);
+    if (sysNameMatch != null && currentInterface != null) {
+      links.add(TopologyLink(from: currentInterface, to: sysNameMatch.group(1)!));
+      currentInterface = null;
+    }
+  }
+  return links;
+}
+
+/// Visible for testing only.
+List<TopologyLink> parseLldpctlForTest(String output) => _parseLldpctl(output);

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 import 'package:nwcd_c/network_scanner.dart';
 import 'package:nwcd_c/network_diagram.dart';
+import 'package:nwcd_c/topology_scanner.dart';
 
 void main() {
   testWidgets('Full scan shows table results', (WidgetTester tester) async {
@@ -44,7 +45,10 @@ void main() {
       ];
     }
 
-    await tester.pumpWidget(MyApp(networkScanFn: fakeScan));
+    await tester.pumpWidget(MyApp(
+      networkScanFn: fakeScan,
+      topologyScanFn: () async => [TopologyLink(from: 'Local', to: 'Device1')],
+    ));
 
     await tester.tap(find.widgetWithText(Tab, 'ネットワーク図'));
     await tester.pumpAndSettle();

--- a/test/topology_scanner_test.dart
+++ b/test/topology_scanner_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/topology_scanner.dart';
+
+void main() {
+  test('parseLldpctlForTest parses neighbors', () {
+    const sample = '''
+Interface:    enp0s3, via: LLDP, RID: 1, Time: 0 day, 00:32:08
+  Chassis:
+    SysName: switch01
+
+Interface:    eth0, via: LLDP, RID: 2, Time: 0 day, 00:32:08
+  Chassis:
+    SysName: router01
+''';
+    final links = parseLldpctlForTest(sample);
+    expect(links.length, 2);
+    expect(links[0].from, 'enp0s3');
+    expect(links[0].to, 'switch01');
+    expect(links[1].from, 'eth0');
+    expect(links[1].to, 'router01');
+  });
+}


### PR DESCRIPTION
## Summary
- implement `topology_scanner.dart` to parse `lldpctl` output
- allow passing custom topology scan function through `MyApp` and `HomePage`
- extend `NetworkDiagram` to visualize discovered topology when available
- update tests for the new API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68804a046a788323b02a632cbb999d20