### PR TITLE
Fix pubspec dependencies

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'scanner.dart';
-import 'network_scanner.dart';
+import 'package:nwcd_c/scanner.dart';
+import 'package:nwcd_c/network_scanner.dart';
 
 class FullScanResult {
   final String target;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # Needed for annotations like @visibleForTesting
+  meta: ^1.16.0
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- add missing `meta` package dependency so annotations like `@visibleForTesting` resolve

## Testing
- `apt-get update`
- `dart pub get` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68804e7810688323b35386de059f3ee8