### PR TITLE
Fix topology parsing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'home_page.dart';
 import 'network_scanner.dart';
+import 'topology_scanner.dart';
 
 void main() {
   runApp(const MyApp());

--- a/lib/topology_scanner.dart
+++ b/lib/topology_scanner.dart
@@ -36,7 +36,7 @@ List<TopologyLink> _parseLldpctl(String output) {
       currentInterface = interfaceMatch.group(1)!.trim();
       continue;
     }
-    final sysNameMatch = RegExp(r'^SysName:\s*(.+)\$').firstMatch(trimmed);
+    final sysNameMatch = RegExp(r'^SysName:\s*(.+)$').firstMatch(trimmed);
     if (sysNameMatch != null && currentInterface != null) {
       links.add(TopologyLink(from: currentInterface, to: sysNameMatch.group(1)!));
       currentInterface = null;


### PR DESCRIPTION
## Summary
- import `topology_scanner.dart` in `main.dart`
- fix SysName regex in topology parsing

## Testing
- `flutter test --reporter expanded` *(fails: Network scan displays diagram)*

------
https://chatgpt.com/codex/tasks/task_e_68805cf3a0508323a3a2c3ac42813ee6