### PR TITLE
Increase network scan timeout

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -77,7 +77,7 @@ class _HomePageState extends State<HomePage>
     NetworkScanResult networkResult;
     try {
       networkResult =
-          await scanNetwork().timeout(const Duration(seconds: 2));
+          await scanNetwork().timeout(const Duration(seconds: 10));
     } on TimeoutException {
       networkResult =
           NetworkScanResult(devices: const [], error: 'Network scan timed out');

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -16,7 +16,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
     // Wait for scan to finish and results to display
-    await tester.pump(const Duration(seconds: 4));
+    await tester.pump(const Duration(seconds: 12));
     await tester.pumpAndSettle();
 
     expect(find.byType(DataTable), findsOneWidget);


### PR DESCRIPTION
## Summary
- extend the timeout for the initial network scan
- update the widget test to wait for the longer scan

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805c9df81883238c82a1cb3009f7b8