### PR TITLE
Update isolate serialization and add tests

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -124,10 +124,19 @@ class _HomePageState extends State<HomePage>
 
     final port = ReceivePort();
     port.listen((message) async {
-      if (message is List<NetworkDevice> && mounted) {
+      if (message is List && mounted) {
+        final devices = message
+            .whereType<Map>()
+            .map((m) => NetworkDevice(
+                  ip: m['ip'] ?? '',
+                  mac: m['mac'] ?? '',
+                  vendor: m['vendor'] ?? '',
+                  name: m['name'] ?? '',
+                ))
+            .toList();
         setState(() {
           _networkScanLoading = false;
-          _networkDevices = message;
+          _networkDevices = devices;
         });
         final topo =
             customTopo != null ? await customTopo() : await scanTopology();

--- a/lib/network_scan_isolate.dart
+++ b/lib/network_scan_isolate.dart
@@ -4,12 +4,20 @@ import 'network_scanner.dart';
 
 /// Entry point for spawning an isolate that runs [scanNetwork].
 ///
-/// The isolate sends the list of discovered [NetworkDevice] back through the
-/// provided [SendPort].
+/// The isolate sends the list of discovered devices as a `List<Map<String,
+/// String>>` back through the provided [SendPort].
 void networkScanIsolate(SendPort sendPort) {
   () async {
     final devices = await scanNetwork();
-    sendPort.send(devices);
+    final serialized = devices
+        .map((d) => {
+              'ip': d.ip,
+              'mac': d.mac,
+              'vendor': d.vendor,
+              'name': d.name,
+            })
+        .toList();
+    sendPort.send(serialized);
     Isolate.exit();
   }();
 }

--- a/test/network_scan_isolate_test.dart
+++ b/test/network_scan_isolate_test.dart
@@ -1,0 +1,36 @@
+import 'dart:isolate';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nwcd_c/main.dart';
+import 'package:nwcd_c/network_diagram.dart';
+import 'package:nwcd_c/network_scan_isolate.dart';
+import 'package:nwcd_c/topology_scanner.dart';
+
+void main() {
+  test('networkScanIsolate sends serialized map data', () async {
+    final port = ReceivePort();
+    await Isolate.spawn(networkScanIsolate, port.sendPort);
+    final message = await port.first;
+    port.close();
+    expect(message, isA<List<Map<String, String>>>());
+  });
+
+  testWidgets('Network diagram displays using isolate results',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp(
+      topologyScanFn: () async => <TopologyLink>[],
+    ));
+
+    await tester.tap(find.widgetWithText(Tab, 'ネットワーク図'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('ネットワークスキャン開始'));
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(NetworkDiagram), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- serialize network scan results in the isolate as maps
- rebuild network device objects from maps in the home page
- test isolate message format and network diagram rendering

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d65506808323b91bd961d90e57a2