### PR TITLE
Improve network scanning messages and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ flutter pub get
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for additional details.
 
+### Required external tools
+The scanning features rely on several command line utilities being available on
+your system:
+
+- `nmap` for network discovery (optional fallback to ping/arp if unavailable)
+- `ping` and `arp` for host detection
+- `ip` or `ifconfig` to enumerate local interfaces
+- `lldpctl` to gather topology information
+
+Make sure these commands are installed and accessible in your `PATH` when
+running the app.
+
 ## Workflows
 
 ### Real-time scan

--- a/lib/topology_scanner.dart
+++ b/lib/topology_scanner.dart
@@ -18,9 +18,16 @@ Future<List<TopologyLink>> scanTopology({
   final run = runLldpctl ?? () => Process.run('lldpctl', []);
   try {
     final result = await run();
-    if (result.exitCode != 0) return [];
+    if (result.exitCode != 0) {
+      print('lldpctl exited with code ${result.exitCode}');
+      return [];
+    }
     return _parseLldpctl(result.stdout as String);
-  } catch (_) {
+  } on ProcessException catch (e) {
+    print('lldpctl command not found: ${e.message}');
+    return [];
+  } catch (e) {
+    print('scanTopology failed: $e');
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- document external tools required for scanning
- log when network scanning utilities are unavailable
- surface messages from topology scans when `lldpctl` isn't present

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8aa44948323af35192cb4ba6dab