### PR TITLE
Inject mock scan function for isolate tests

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -105,22 +105,6 @@ class _HomePageState extends State<HomePage>
 
     final customScan = widget.scanNetworkFn;
     final customTopo = widget.scanTopologyFn;
-    if (customScan != null) {
-      final devices = await customScan();
-      if (!mounted) return;
-      setState(() {
-        _networkScanLoading = false;
-        _networkDevices = devices;
-      });
-      final topo =
-          customTopo != null ? await customTopo() : await scanTopology();
-      if (!mounted) return;
-      setState(() {
-        _topologyLoading = false;
-        _topology = topo;
-      });
-      return;
-    }
 
     final port = ReceivePort();
     port.listen((message) async {
@@ -149,7 +133,12 @@ class _HomePageState extends State<HomePage>
         port.close();
       }
     });
-    await Isolate.spawn(networkScanIsolate, port.sendPort);
+
+    if (customScan != null) {
+      await Isolate.spawn(networkScanIsolate, [port.sendPort, customScan]);
+    } else {
+      await Isolate.spawn(networkScanIsolate, port.sendPort);
+    }
   }
 
   @override

--- a/lib/network_scan_isolate.dart
+++ b/lib/network_scan_isolate.dart
@@ -2,13 +2,31 @@ import 'dart:isolate';
 
 import 'network_scanner.dart';
 
-/// Entry point for spawning an isolate that runs [scanNetwork].
+/// Signature for a function that scans the network.
+typedef ScanNetworkFn = Future<List<NetworkDevice>> Function();
+
+/// Entry point for spawning an isolate that runs a network scan.
 ///
-/// The isolate sends the list of discovered devices as a `List<Map<String,
-/// String>>` back through the provided [SendPort].
-void networkScanIsolate(SendPort sendPort) {
+/// The [message] may be either a [SendPort] or a `[SendPort, ScanNetworkFn]`
+/// tuple. The isolate sends the list of discovered devices as a
+/// `List<Map<String, String>>` back through the provided [SendPort].
+void networkScanIsolate(dynamic message) {
+  late final SendPort sendPort;
+  ScanNetworkFn scanFn = scanNetwork;
+
+  if (message is SendPort) {
+    sendPort = message;
+  } else if (message is List && message.isNotEmpty && message[0] is SendPort) {
+    sendPort = message[0] as SendPort;
+    if (message.length > 1 && message[1] is Function) {
+      scanFn = message[1] as ScanNetworkFn;
+    }
+  } else {
+    throw ArgumentError('Invalid message for networkScanIsolate');
+  }
+
   () async {
-    final devices = await scanNetwork();
+    final devices = await scanFn();
     final serialized = devices
         .map((d) => {
               'ip': d.ip,

--- a/test/network_scan_isolate_test.dart
+++ b/test/network_scan_isolate_test.dart
@@ -4,12 +4,24 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
 import 'package:nwcd_c/network_diagram.dart';
 import 'package:nwcd_c/network_scan_isolate.dart';
+import 'package:nwcd_c/network_scanner.dart';
 import 'package:nwcd_c/topology_scanner.dart';
 
 void main() {
+  Future<List<NetworkDevice>> fakeScan() async {
+    return [
+      NetworkDevice(
+        ip: '192.168.1.2',
+        mac: '00:11:22:33:44:55',
+        vendor: 'TestVendor',
+        name: 'Device1',
+      ),
+    ];
+  }
+
   test('networkScanIsolate sends serialized map data', () async {
     final port = ReceivePort();
-    await Isolate.spawn(networkScanIsolate, port.sendPort);
+    await Isolate.spawn(networkScanIsolate, [port.sendPort, fakeScan]);
     final message = await port.first;
     port.close();
     expect(message, isA<List<Map<String, String>>>());
@@ -18,6 +30,7 @@ void main() {
   testWidgets('Network diagram displays using isolate results',
       (WidgetTester tester) async {
     await tester.pumpWidget(MyApp(
+      networkScanFn: fakeScan,
       topologyScanFn: () async => <TopologyLink>[],
     ));
 


### PR DESCRIPTION
## Summary
- allow `networkScanIsolate` to accept an injected scan function via spawn message
- update `_startNetworkScan` to pass the scan function to the isolate
- use fake scan implementation in `network_scan_isolate_test.dart`

## Testing
- `flutter format -n lib/network_scan_isolate.dart lib/home_page.dart test/network_scan_isolate_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e8bf2e308323983f66e699dca858