### PR TITLE
Add risk summary tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nwcd_c
 
-This Flutter project contains a minimal home screen with three tabs:
+This Flutter project contains a minimal home screen with four tabs:
 **リアルタイム診断** for a quick real-time scan, **フルスキャン** for a full
-network scan, and **ネットワーク図** for displaying a network diagram.
+network scan, **ネットワーク図** for displaying a network diagram, and
+**リスクまとめ** for a brief overview of common security risks.
 Pressing either scan button shows a short progress indicator. Once the
 actual scanning logic is implemented, each workflow will navigate to a results
 page summarizing the findings.
@@ -62,6 +63,10 @@ choco install nmap
 ### Network diagram
 1. Tap **ネットワーク図** on the home screen.
 2. A placeholder diagram is displayed showing where network visuals will appear.
+
+### リスクまとめ
+1. Tap **リスクまとめ** on the home screen.
+2. A single page lists common network security risks for quick reference.
 
 **Note:** Only run network scans against systems you are authorized to test.
 Unauthorized scanning can be illegal or violate terms of service.

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:nwcd_c/scanner.dart';
 import 'package:nwcd_c/network_scanner.dart';
+import 'package:nwcd_c/risk_summary_page.dart';
 
 class FullScanResult {
   final String target;
@@ -38,7 +39,7 @@ class _HomePageState extends State<HomePage>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(length: 4, vsync: this);
   }
 
   void _startRealTimeScan() {
@@ -146,6 +147,7 @@ class _HomePageState extends State<HomePage>
             Tab(text: 'リアルタイム診断'),
             Tab(text: 'フルスキャン'),
             Tab(text: 'ネットワーク図'),
+            Tab(text: 'リスクまとめ'),
           ],
         ),
       ),
@@ -155,6 +157,7 @@ class _HomePageState extends State<HomePage>
           _buildRealtimeTab(),
           _buildFullScanTab(),
           _buildNetworkDiagramTab(),
+          const RiskSummaryPage(),
         ],
       ),
     );

--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Static summary of common network security risks highlighted in README.
+class RiskSummaryPage extends StatelessWidget {
+  const RiskSummaryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bullet = '\u2022';
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: ListView(
+        children: [
+          Text(
+            'リスク要約',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          Text('$bullet 無許可のネットワークスキャンは違法となる可能性があります。'),
+          const SizedBox(height: 8),
+          Text('$bullet 不要な開放ポートは攻撃の入口となります。'),
+          const SizedBox(height: 8),
+          Text('$bullet OSやソフトウェアの未更新は既知の脆弱性(CVE)悪用に繋がります。'),
+          const SizedBox(height: 8),
+          Text('$bullet デバイス/ソフトウェアのバージョンを把握し、脆弱性情報と照合することが重要です。'),
+        ],
+      ),
+    );
+  }
+}

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -27,4 +27,14 @@ void main() {
     expect(find.textContaining('.'), findsWidgets);
     expect(find.text('フルスキャン開始'), findsOneWidget);
   });
+
+  testWidgets('Risk summary tab displays text', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.tap(find.widgetWithText(Tab, 'リスクまとめ'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('リスク要約'), findsOneWidget);
+    expect(find.textContaining('ネットワークスキャン'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- display a static "Risk Summary" page with a new widget
- add a fourth tab in `HomePage` to show risk information
- update README to mention the new tab and usage
- add a widget test for the risk summary tab

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e99fc2e083238a07d88788d95adc