### PR TITLE
Add insecure protocol demo

### DIFF
--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -31,6 +31,40 @@ class RiskSummaryPage extends StatelessWidget {
           Text('$bullet 管理インターフェースの外部公開'),
           const SizedBox(height: 8),
           Text('$bullet ネットワーク分割や監視体制の不足'),
+          const SizedBox(height: 24),
+          Text(
+            '危険な通信デモ',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('宛先ホスト名/IP')),
+              DataColumn(label: Text('通信種別')),
+              DataColumn(label: Text('暗号化状態')),
+            ],
+            rows: const [
+              DataRow(cells: [
+                DataCell(Text('test.example.com')),
+                DataCell(Text('HTTP')),
+                DataCell(Text('暗号化なし')),
+              ]),
+              DataRow(cells: [
+                DataCell(Text('printer.local')),
+                DataCell(Text('TELNET')),
+                DataCell(Text('暗号化なし')),
+              ]),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.all(8),
+            color: Colors.black12,
+            child: const Text(
+              'GET / HTTP/1.1\nHost: test.example.com',
+              style: TextStyle(fontFamily: 'monospace'),
+            ),
+          ),
         ],
       ),
     );

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -40,5 +40,12 @@ void main() {
     expect(find.textContaining('安全でないプロトコル'), findsOneWidget);
     expect(find.textContaining('管理インターフェースの外部公開'), findsOneWidget);
     expect(find.textContaining('ネットワーク分割や監視体制の不足'), findsOneWidget);
+    expect(find.text('危険な通信デモ'), findsOneWidget);
+    expect(find.text('宛先ホスト名/IP'), findsOneWidget);
+    expect(find.text('通信種別'), findsOneWidget);
+    expect(find.text('暗号化状態'), findsOneWidget);
+    expect(find.text('test.example.com'), findsOneWidget);
+    expect(find.text('HTTP'), findsOneWidget);
+    expect(find.text('TELNET'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- show sample unencrypted traffic table on risk summary page
- test UI elements for the new section

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c40a2348832397826741a3c2d251