### PR TITLE
Add demo country chart and table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Flutter, fetch dependencies with:
 flutter pub get
 ```
 
+The project depends on the `charts_flutter` package for displaying charts in
+the risk summary demo.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for additional details.
 
 ## Required command-line tools
@@ -66,7 +69,9 @@ choco install nmap
 
 ### リスクまとめ
 1. Tap **リスクまとめ** on the home screen.
-2. A single page lists common network security risks for quick reference.
+2. A single page lists common network security risks for quick reference and
+   includes a demo table and pie chart summarizing recent connections by
+   destination country.
    - 無許可のネットワークスキャンは違法となる可能性があります。
    - 不要な開放ポートは攻撃の入口となります。
    - OSやソフトウェアの未更新は既知の脆弱性(CVE)悪用に繋がります。

--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -1,8 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
+
+class _CountryConnection {
+  final String country;
+  final int count;
+
+  _CountryConnection(this.country, this.count);
+}
 
 /// Static summary of common network security risks highlighted in README.
 class RiskSummaryPage extends StatelessWidget {
   const RiskSummaryPage({super.key});
+
+  static final List<_CountryConnection> _sampleData = [
+    _CountryConnection('日本', 134),
+    _CountryConnection('アメリカ', 27),
+    _CountryConnection('ロシア', 2),
+  ];
+
+  List<charts.Series<_CountryConnection, String>> _createSeries() {
+    return [
+      charts.Series<_CountryConnection, String>(
+        id: 'Connections',
+        domainFn: (d, _) => d.country,
+        measureFn: (d, _) => d.count,
+        data: _sampleData,
+        labelAccessorFn: (d, _) => '${d.country}: ${d.count}',
+      )
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +57,35 @@ class RiskSummaryPage extends StatelessWidget {
           Text('$bullet 管理インターフェースの外部公開'),
           const SizedBox(height: 8),
           Text('$bullet ネットワーク分割や監視体制の不足'),
+          const SizedBox(height: 32),
+          Text('通信先の国 一覧表示',
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 200,
+            child: charts.PieChart(
+              _createSeries(),
+              animate: false,
+              defaultRenderer: charts.ArcRendererConfig(
+                arcRendererDecorators: [charts.ArcLabelDecorator()],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('国名')),
+              DataColumn(label: Text('通信回数（件）')),
+            ],
+            rows: _sampleData
+                .map(
+                  (d) => DataRow(cells: [
+                    DataCell(Text(d.country)),
+                    DataCell(Text('${d.count}')),
+                  ]),
+                )
+                .toList(),
+          ),
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  charts_flutter: ^0.12.0
 
 dev_dependencies:
   flutter_test:

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nwcd_c/main.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
 
 void main() {
   testWidgets('Full scan shows table results', (WidgetTester tester) async {
@@ -40,5 +41,9 @@ void main() {
     expect(find.textContaining('安全でないプロトコル'), findsOneWidget);
     expect(find.textContaining('管理インターフェースの外部公開'), findsOneWidget);
     expect(find.textContaining('ネットワーク分割や監視体制の不足'), findsOneWidget);
+    expect(find.byType(DataTable), findsOneWidget);
+    expect(find.text('日本'), findsOneWidget);
+    expect(find.text('134'), findsOneWidget);
+    expect(find.byType(charts.PieChart), findsOneWidget);
   });
 }

--- a/test/risk_summary_country_test.dart
+++ b/test/risk_summary_country_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
+import 'package:nwcd_c/risk_summary_page.dart';
+
+void main() {
+  testWidgets('Country summary table and chart render demo data',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: RiskSummaryPage()));
+
+    expect(find.text('通信先の国 一覧表示'), findsOneWidget);
+    expect(find.byType(DataTable), findsOneWidget);
+    expect(find.text('日本'), findsOneWidget);
+    expect(find.text('134'), findsOneWidget);
+    expect(find.byType(charts.PieChart), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- show a pie chart and table on the risk summary tab with placeholder data
- mention `charts_flutter` in setup instructions
- test that demo data is rendered

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c3bf72988323a6e17ab155ca4e4f