### PR TITLE
Add abnormal traffic table to risk summary demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ choco install nmap
    - 安全でないプロトコル (HTTP/Telnet) の使用
    - 管理インターフェースの外部公開
    - ネットワーク分割や監視体制の不足
+   - 通信量が異常な機器のランキング表示
 
 **Note:** Only run network scans against systems you are authorized to test.
 Unauthorized scanning can be illegal or violate terms of service.

--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -104,6 +104,36 @@ class RiskSummaryPage extends StatelessWidget {
               style: TextStyle(fontFamily: 'monospace'),
             ),
           ),
+          const SizedBox(height: 24),
+          Text(
+            '通信量が異常な機器',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('IPアドレス')),
+              DataColumn(label: Text('デバイス名')),
+              DataColumn(label: Text('通信量（MB/分）')),
+            ],
+            rows: const [
+              DataRow(cells: [
+                DataCell(Text('192.168.0.12')),
+                DataCell(Text('PC-A')),
+                DataCell(Text('327')),
+              ]),
+              DataRow(cells: [
+                DataCell(Text('192.168.0.21')),
+                DataCell(Text('NAS-Server')),
+                DataCell(Text('215')),
+              ]),
+              DataRow(cells: [
+                DataCell(Text('192.168.0.3')),
+                DataCell(Text('不明な機器')),
+                DataCell(Text('200')),
+              ]),
+            ],
+          ),
         ],
       ),
     );

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -52,5 +52,11 @@ void main() {
     expect(find.text('test.example.com'), findsOneWidget);
     expect(find.text('HTTP'), findsOneWidget);
     expect(find.text('TELNET'), findsOneWidget);
+    expect(find.text('通信量が異常な機器'), findsOneWidget);
+    expect(find.text('IPアドレス'), findsOneWidget);
+    expect(find.text('デバイス名'), findsOneWidget);
+    expect(find.text('通信量（MB/分）'), findsOneWidget);
+    expect(find.text('192.168.0.12'), findsOneWidget);
+    expect(find.text('PC-A'), findsOneWidget);
   });
 }

--- a/test/risk_summary_country_test.dart
+++ b/test/risk_summary_country_test.dart
@@ -11,7 +11,9 @@ void main() {
     expect(find.text('通信先の国 一覧表示'), findsOneWidget);
     expect(find.byType(DataTable), findsOneWidget);
     expect(find.text('日本'), findsOneWidget);
-    expect(find.text('134'), findsOneWidget);
-    expect(find.byType(charts.PieChart), findsOneWidget);
+  expect(find.text('134'), findsOneWidget);
+  expect(find.byType(charts.PieChart), findsOneWidget);
+  expect(find.text('通信量が異常な機器'), findsOneWidget);
+  expect(find.text('192.168.0.12'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- expand README risk summary bullet list
- show a demo table of devices with abnormal traffic on risk summary page
- update widget tests for new demo table

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c9136f4483238f8498ec45410e64