### PR TITLE
Fix closing paren in RiskSummary DataTable

### DIFF
--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -70,6 +70,7 @@ class RiskSummaryPage extends StatelessWidget {
                   ]),
                 )
                 .toList(),
+          ),
           const SizedBox(height: 24),
           Text(
             '危険な通信デモ',


### PR DESCRIPTION
## Summary
- fix a missing comma/parentheses in `RiskSummaryPage`

## Testing
- `flutter analyze lib`

------
https://chatgpt.com/codex/tasks/task_e_6882cb997ae883239cb269c42f931538