### PR TITLE
Add demo for risky ports table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ choco install nmap
    - 安全でないプロトコル (HTTP/Telnet) の使用
    - 管理インターフェースの外部公開
    - ネットワーク分割や監視体制の不足
+   - 危険なポートが開いている機器のリスト表示
    - 通信量が異常な機器のランキング表示
 
 **Note:** Only run network scans against systems you are authorized to test.

--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -107,6 +107,31 @@ class RiskSummaryPage extends StatelessWidget {
           ),
           const SizedBox(height: 24),
           Text(
+            '危険なポートが開いている機器',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('IPアドレス')),
+              DataColumn(label: Text('機器名')),
+              DataColumn(label: Text('開いている危険ポート')),
+            ],
+            rows: const [
+              DataRow(cells: [
+                DataCell(Text('192.168.0.12')),
+                DataCell(Text('PC-A')),
+                DataCell(Text('3389, 445')),
+              ]),
+              DataRow(cells: [
+                DataCell(Text('192.168.0.34')),
+                DataCell(Text('古いNAS装置')),
+                DataCell(Text('23（TELNET）')),
+              ]),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text(
             '通信量が異常な機器',
             style: Theme.of(context).textTheme.titleMedium,
           ),


### PR DESCRIPTION
## Summary
- show demo table of devices with risky open ports on Risk Summary tab
- mention new risky port list feature in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d19c8c788323a07c6f18e9e76b84