### PR TITLE
Remove trailing spaces in risk_summary_page.dart

### DIFF
--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -41,7 +41,7 @@ class RiskSummaryPage extends StatelessWidget {
             'リスク要約',
             style: Theme.of(context).textTheme.titleLarge,
           ),
-          
+
           const SizedBox(height: 32),
           Text('$bullet 通信先の国 一覧表示',
               style: Theme.of(context).textTheme.titleMedium),


### PR DESCRIPTION
## Summary
- clean up whitespace on risk summary page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e7caa550832388f61053bc6ccdda