### PR TITLE
Add note on rerunning pub get

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,11 @@ Thank you for considering contributing to **nwcd_c**!
 2. Clone this repository and fetch dependencies:
 
    ```bash
-   flutter pub get
-   ```
+flutter pub get
+```
+
+3. Whenever you change **pubspec.yaml**, run `flutter pub get` again so all
+   packages are up to date.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Flutter, fetch dependencies with:
 flutter pub get
 ```
 
+Whenever you modify **pubspec.yaml**, run `flutter pub get` again so the
+`pubspec.lock` file and your local packages stay in sync.
+
 The project depends on the `charts_flutter` package for displaying charts in
 the risk summary demo.
 


### PR DESCRIPTION
## Summary
- update README setup section
- clarify in CONTRIBUTING that pub get must be rerun after pubspec edits

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e7d018008323a809e3e058d61209