### PR TITLE
Add ARP spoofing demo to risk summary

### DIFF
--- a/lib/risk_summary_page.dart
+++ b/lib/risk_summary_page.dart
@@ -160,6 +160,32 @@ class RiskSummaryPage extends StatelessWidget {
               ]),
             ],
           ),
+          const SizedBox(height: 24),
+          Text(
+            '⚠️ 異常検出',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            '同じIPに異なるMACアドレスが複数存在します。\n通信なりすまし（ARPスプーフィング）のリスクがあります。',
+          ),
+          const SizedBox(height: 8),
+          DataTable(
+            columns: const [
+              DataColumn(label: Text('IPアドレス')),
+              DataColumn(label: Text('MACアドレス')),
+            ],
+            rows: const [
+              DataRow(cells: [
+                DataCell(Text('192.168.0.15')),
+                DataCell(Text('AA:BB:CC:DD:EE:01')),
+              ]),
+              DataRow(cells: [
+                DataCell(Text('192.168.0.15')),
+                DataCell(Text('AA:BB:CC:DD:EE:99')),
+              ]),
+            ],
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- expand the risk summary page with a demo detecting multiple MAC addresses for a single IP

## Testing
- `apt-get update` *(fails: 403 Forbidden for mise.jdx.dev)*
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882eb7d3228832397229a51574c1113