### PR TITLE
Rename full scan tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nwcd_c
 
 This Flutter project contains a minimal home screen with four tabs:
-**リアルタイム診断** for a quick real-time scan, **フルスキャン** for a full
+**リアルタイム診断** for a quick real-time scan, **フルスキャン診断** for a full
 network scan, **ネットワーク図** for displaying a network diagram, and
 **リスクまとめ** for a brief overview of common security risks.
 Pressing either scan button shows a short progress indicator. Once the
@@ -60,7 +60,7 @@ choco install nmap
 3. When finished, it navigates to the results page.
 
 ### Full scan
-1. Tap **フルスキャン** on the home screen.
+1. Tap **フルスキャン診断** on the home screen.
 2. A more thorough scan is executed and a progress indicator is shown.
 3. After completion, the app navigates to the results page.
 

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -145,7 +145,7 @@ class _HomePageState extends State<HomePage>
           controller: _tabController,
           tabs: const [
             Tab(text: 'リアルタイム診断'),
-            Tab(text: 'フルスキャン'),
+            Tab(text: 'フルスキャン診断'),
             Tab(text: 'ネットワーク図'),
             Tab(text: 'リスクまとめ'),
           ],

--- a/test/home_page_test.dart
+++ b/test/home_page_test.dart
@@ -8,7 +8,7 @@ void main() {
     await tester.pumpWidget(const MyApp());
 
     // Navigate to full scan tab
-    await tester.tap(find.widgetWithText(Tab, 'フルスキャン'));
+    await tester.tap(find.widgetWithText(Tab, 'フルスキャン診断'));
     await tester.pumpAndSettle();
 
     // Start full scan and expect progress indicator


### PR DESCRIPTION
## Summary
- update "フルスキャン" tab text to "フルスキャン診断"
- adjust tests and docs for the new tab name

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884879cbd4883239873d0bce63917db